### PR TITLE
Add Current Test/Class elements

### DIFF
--- a/visual-dotnet/SauceLabs.Visual.Tests/VisualApiTest.cs
+++ b/visual-dotnet/SauceLabs.Visual.Tests/VisualApiTest.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using NUnit.Framework;
 using RichardSzalay.MockHttp;
 using SauceLabs.Visual.GraphQL;

--- a/visual-dotnet/SauceLabs.Visual/GraphQL/CreateSnapshotFromWebDriverIn.cs
+++ b/visual-dotnet/SauceLabs.Visual/GraphQL/CreateSnapshotFromWebDriverIn.cs
@@ -38,7 +38,9 @@ namespace SauceLabs.Visual.GraphQL
             DiffingMethod diffingMethod,
             RegionIn[] regions,
             bool captureDom,
-            string? clipSelector
+            string? clipSelector,
+            string? suiteName,
+            string? testName
         )
         {
             BuildUuid = buildUuid;
@@ -50,6 +52,8 @@ namespace SauceLabs.Visual.GraphQL
             SessionId = sessionId;
             CaptureDom = captureDom;
             ClipSelector = clipSelector;
+            SuiteName = suiteName;
+            TestName = testName;
         }
     }
 }

--- a/visual-dotnet/SauceLabs.Visual/Utils/GraphQLResponseExtension.cs
+++ b/visual-dotnet/SauceLabs.Visual/Utils/GraphQLResponseExtension.cs
@@ -3,7 +3,7 @@ using GraphQL;
 
 namespace SauceLabs.Visual.Utils
 {
-    public static class GraphQLResponseExtension
+    internal static class GraphQLResponseExtension
     {
         public static T EnsureValidResponse<T>(this GraphQLResponse<T> response)
         {

--- a/visual-dotnet/SauceLabs.Visual/Utils/StringUtils.cs
+++ b/visual-dotnet/SauceLabs.Visual/Utils/StringUtils.cs
@@ -1,6 +1,6 @@
 namespace SauceLabs.Visual.Utils
 {
-    public static class StringUtils
+    internal static class StringUtils
     {
         /// <summary>
         /// <c>IsNullOrEmpty</c> checks that the string null, empty or contains only whitespaces.

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
@@ -15,7 +15,13 @@ namespace SauceLabs.Visual
         public bool? CaptureDom { get; set; }
         public string? ClipSelector { get; set; }
 
+        /// <summary>
+        /// <c>SuiteName</c> manually set the SuiteName of the Test.
+        /// </summary>
         public string? SuiteName { get; set; }
+        /// <summary>
+        /// <c>TestName</c> manually set the TestName of the Test.
+        /// </summary>
         public string? TestName { get; set; }
     }
 }

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
@@ -28,15 +28,17 @@ namespace SauceLabs.Visual
 
         private bool HasIncompleteTestContext() => string.IsNullOrEmpty(SuiteName) || string.IsNullOrEmpty(TestName);
 
-        internal void PopulateTestContext(string callerMemberName, string? previousSuiteName)
+        internal void EnsureTestContextIsPopulated(string callerMemberName, string? previousSuiteName)
         {
-            if (!string.IsNullOrEmpty(callerMemberName) && HasIncompleteTestContext())
+            if (string.IsNullOrEmpty(callerMemberName) || HasIncompleteTestContext())
             {
-                var stack = new StackTrace();
-                var frame = stack.GetFrames()?.FirstOrDefault(f => f.GetMethod().Name == callerMemberName);
-                SuiteName ??= frame?.GetMethod().DeclaringType?.FullName ?? previousSuiteName;
-                TestName ??= callerMemberName;
+                return;
             }
+
+            var stack = new StackTrace();
+            var frame = stack.GetFrames()?.FirstOrDefault(f => f.GetMethod().Name == callerMemberName);
+            SuiteName ??= frame?.GetMethod().DeclaringType?.FullName ?? previousSuiteName;
+            TestName ??= callerMemberName;
         }
     }
 }

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
@@ -23,5 +23,7 @@ namespace SauceLabs.Visual
         /// <c>TestName</c> manually set the TestName of the Test.
         /// </summary>
         public string? TestName { get; set; }
+
+        internal bool HasIncompleteTestContext() => string.IsNullOrEmpty(SuiteName) || string.IsNullOrEmpty(TestName);
     }
 }

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Linq;
 using OpenQA.Selenium;
 using SauceLabs.Visual.Models;
 
@@ -24,6 +26,17 @@ namespace SauceLabs.Visual
         /// </summary>
         public string? TestName { get; set; }
 
-        internal bool HasIncompleteTestContext() => string.IsNullOrEmpty(SuiteName) || string.IsNullOrEmpty(TestName);
+        private bool HasIncompleteTestContext() => string.IsNullOrEmpty(SuiteName) || string.IsNullOrEmpty(TestName);
+
+        internal void PopulateTestContext(string callerMemberName, string? previousSuiteName)
+        {
+            if (!string.IsNullOrEmpty(callerMemberName) && HasIncompleteTestContext())
+            {
+                var stack = new StackTrace();
+                var frame = stack.GetFrames()?.FirstOrDefault(f => f.GetMethod().Name == callerMemberName);
+                SuiteName ??= frame?.GetMethod().DeclaringType?.FullName ?? previousSuiteName;
+                TestName ??= callerMemberName;
+            }
+        }
     }
 }

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
@@ -14,5 +14,8 @@ namespace SauceLabs.Visual
         public IWebElement[]? IgnoreElements { get; set; }
         public bool? CaptureDom { get; set; }
         public string? ClipSelector { get; set; }
+
+        public string? ClassName { get; set; }
+        public string? TestName { get; set; }
     }
 }

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
@@ -15,7 +15,7 @@ namespace SauceLabs.Visual
         public bool? CaptureDom { get; set; }
         public string? ClipSelector { get; set; }
 
-        public string? ClassName { get; set; }
+        public string? SuiteName { get; set; }
         public string? TestName { get; set; }
     }
 }

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -253,7 +253,6 @@ namespace SauceLabs.Visual
 
         private async Task<string> VisualCheckAsync(string name, VisualCheckOptions options)
         {
-
             var ignored = new List<RegionIn>();
             ignored.AddRange(options.IgnoreRegions?.Select(r => new RegionIn(r)) ?? new List<RegionIn>());
             ignored.AddRange(options.IgnoreElements?.Select(r => new RegionIn(r)) ?? new List<RegionIn>());

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -78,7 +78,7 @@ namespace SauceLabs.Visual
         /// <param name="buildOptions">the options of the build creation</param>
         public static async Task<VisualClient> Create(WebDriver wd, Region region, string username, string accessKey, CreateBuildOptions buildOptions)
         {
-            var client = new VisualClient(wd, Region.UsWest1, username, accessKey);
+            var client = new VisualClient(wd, region, username, accessKey);
             await client.SetupBuild(buildOptions);
             return client;
         }

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -229,7 +229,7 @@ namespace SauceLabs.Visual
             [CallerMemberName] string callerMemberName = "")
         {
             options ??= new VisualCheckOptions();
-            if (!string.IsNullOrEmpty(callerMemberName) && (string.IsNullOrEmpty(options.SuiteName) || string.IsNullOrEmpty(options.TestName)))
+            if (!string.IsNullOrEmpty(callerMemberName) && options.HasIncompleteTestContext())
             {
                 var stack = new StackTrace();
                 var frame = stack.GetFrames()?.FirstOrDefault(f => f.GetMethod().Name == callerMemberName);

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -254,9 +254,8 @@ namespace SauceLabs.Visual
                 regions: ignored.ToArray(),
                 sessionId: _sessionId,
                 sessionMetadata: _sessionMetadataBlob ?? "",
-                captureDom: options?.CaptureDom ?? CaptureDom,
-                clipSelector: options?.ClipSelector,
                 captureDom: options.CaptureDom ?? CaptureDom,
+                clipSelector: options.ClipSelector,
                 suiteName: options.SuiteName,
                 testName: options.TestName
             ))).EnsureValidResponse();

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -26,6 +26,11 @@ namespace SauceLabs.Visual
         public bool CaptureDom { get; set; } = false;
         private readonly ResiliencePipeline _retryPipeline;
 
+        public string? CurrentTestName { get; set; }
+        public string? CurrentTestClass { get; set; }
+
+        #region Create
+
         /// <summary>
         /// Creates a new instance of <c>VisualClient</c>
         /// </summary>
@@ -69,10 +74,13 @@ namespace SauceLabs.Visual
         /// <param name="buildOptions">the options of the build creation</param>
         public static async Task<VisualClient> Create(WebDriver wd, Region region, string username, string accessKey, CreateBuildOptions buildOptions)
         {
-            var client = new VisualClient(wd, region, username, accessKey);
+            var client = new VisualClient(wd, Region.UsWest1, username, accessKey);
             await client.SetupBuild(buildOptions);
             return client;
         }
+        #endregion
+
+        #region Setup
 
         private async Task SetupBuild(CreateBuildOptions buildOptions)
         {
@@ -204,6 +212,8 @@ namespace SauceLabs.Visual
             return new VisualBuild(result.Result.Id, result.Result.Url, result.Result.Mode);
         }
 
+        #endregion
+
         /// <summary>
         /// <c>FinishBuild</c> finishes a build
         /// </summary>
@@ -235,7 +245,9 @@ namespace SauceLabs.Visual
                 sessionId: _sessionId,
                 sessionMetadata: _sessionMetadataBlob ?? "",
                 captureDom: options?.CaptureDom ?? CaptureDom,
-                clipSelector: options?.ClipSelector
+                clipSelector: options?.ClipSelector,
+                suiteName: CurrentTestClass,
+                testName: CurrentTestName
             ))).EnsureValidResponse();
             result.Result.Diffs.Nodes.ToList().ForEach(d => _screenshotIds.Add(d.Id));
             return result.Result.Id;

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -229,14 +229,8 @@ namespace SauceLabs.Visual
             [CallerMemberName] string callerMemberName = "")
         {
             options ??= new VisualCheckOptions();
-            if (!string.IsNullOrEmpty(callerMemberName) && options.HasIncompleteTestContext())
-            {
-                var stack = new StackTrace();
-                var frame = stack.GetFrames()?.FirstOrDefault(f => f.GetMethod().Name == callerMemberName);
-                options.SuiteName ??= frame?.GetMethod().DeclaringType?.FullName ?? _previousSuiteName;
-                options.TestName ??= callerMemberName;
-                _previousSuiteName = options.SuiteName;
-            }
+            options.PopulateTestContext(callerMemberName, _previousSuiteName);
+            _previousSuiteName = options.SuiteName;
             return VisualCheckAsync(name, options);
         }
 

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -29,11 +29,7 @@ namespace SauceLabs.Visual
         public bool CaptureDom { get; set; } = false;
         private readonly ResiliencePipeline _retryPipeline;
 
-        public string? CurrentTestClass { get; set; }
-        public string? CurrentTestName { get; set; }
         private string? _previousTestClass = null;
-
-        #region Create
 
         /// <summary>
         /// Creates a new instance of <c>VisualClient</c>
@@ -82,9 +78,6 @@ namespace SauceLabs.Visual
             await client.SetupBuild(buildOptions);
             return client;
         }
-        #endregion
-
-        #region Setup
 
         private async Task SetupBuild(CreateBuildOptions buildOptions)
         {
@@ -217,8 +210,6 @@ namespace SauceLabs.Visual
             })).EnsureValidResponse();
             return new VisualBuild(result.Result.Id, result.Result.Url, result.Result.Mode);
         }
-
-        #endregion
 
         /// <summary>
         /// <c>FinishBuild</c> finishes a build

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -229,7 +229,7 @@ namespace SauceLabs.Visual
             [CallerMemberName] string callerMemberName = "")
         {
             options ??= new VisualCheckOptions();
-            options.PopulateTestContext(callerMemberName, _previousSuiteName);
+            options.EnsureTestContextIsPopulated(callerMemberName, _previousSuiteName);
             _previousSuiteName = options.SuiteName;
             return VisualCheckAsync(name, options);
         }

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -198,12 +198,10 @@ namespace SauceLabs.Visual
         /// <returns>a <c>VisualBuild</c> instance</returns>
         private async Task<VisualBuild> CreateBuild(CreateBuildOptions? options = null)
         {
-            var projectName = options?.Project ?? Assembly.GetExecutingAssembly().FullName;
-
             var result = (await _api.CreateBuild(new CreateBuildIn
             {
                 Name = options?.Name,
-                Project = projectName,
+                Project = options?.Project,
                 Branch = options?.Branch,
                 CustomId = options?.CustomId,
                 DefaultBranch = options?.DefaultBranch,

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -29,7 +29,7 @@ namespace SauceLabs.Visual
         public bool CaptureDom { get; set; } = false;
         private readonly ResiliencePipeline _retryPipeline;
 
-        private string? _previousTestClass = null;
+        private string? _previousSuiteName = null;
 
         /// <summary>
         /// Creates a new instance of <c>VisualClient</c>
@@ -231,13 +231,13 @@ namespace SauceLabs.Visual
             [CallerMemberName] string callerMemberName = "")
         {
             options ??= new VisualCheckOptions();
-            if (!string.IsNullOrEmpty(callerMemberName) && (string.IsNullOrEmpty(options.ClassName) || string.IsNullOrEmpty(options.TestName)))
+            if (!string.IsNullOrEmpty(callerMemberName) && (string.IsNullOrEmpty(options.SuiteName) || string.IsNullOrEmpty(options.TestName)))
             {
                 var stack = new StackTrace();
                 var frame = stack.GetFrames()?.FirstOrDefault(f => f.GetMethod().Name == callerMemberName);
-                options.ClassName ??= frame?.GetMethod().DeclaringType?.FullName ?? _previousTestClass;
+                options.SuiteName ??= frame?.GetMethod().DeclaringType?.FullName ?? _previousSuiteName;
                 options.TestName ??= callerMemberName;
-                _previousTestClass = options.ClassName;
+                _previousSuiteName = options.SuiteName;
             }
             return VisualCheckAsync(name, options);
         }
@@ -259,7 +259,7 @@ namespace SauceLabs.Visual
                 captureDom: options?.CaptureDom ?? CaptureDom,
                 clipSelector: options?.ClipSelector,
                 captureDom: options.CaptureDom ?? CaptureDom,
-                suiteName: options.ClassName,
+                suiteName: options.SuiteName,
                 testName: options.TestName
             ))).EnsureValidResponse();
             result.Result.Diffs.Nodes.ToList().ForEach(d => _screenshotIds.Add(d.Id));

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using OpenQA.Selenium;

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -269,6 +269,12 @@ namespace SauceLabs.Visual
             _api.Dispose();
         }
 
+        public void ResetCurrentTest()
+        {
+            CurrentTestClass = null;
+            CurrentTestName = null;
+        }
+
         /// <summary>
         /// <c>VisualResults</c> returns the results of screenshot comparison.
         /// </summary>


### PR DESCRIPTION
# One-line summary

> Issue : IRIS-834

## Description

- Exposes fields to set context
- Move classes from `public` to `internal` as they should not be exposed
- Expose `CurrentTestName` & `CurrentClassName` so it can be overridden by user.

## Types of Changes

- New feature (non-breaking change which adds functionality)

