### PR TITLE
Ensure build is shared across all test classes

### DIFF
--- a/visual-dotnet/SauceLabs.Visual.Tests/BuildFactoryTest.cs
+++ b/visual-dotnet/SauceLabs.Visual.Tests/BuildFactoryTest.cs
@@ -37,7 +37,7 @@ public class BuildFactoryTest
         var base64EncodedAuthenticationString =
             Convert.ToBase64String(Encoding.ASCII.GetBytes($"{_username}:{_accessKey}"));
         var regions = new[] { Region.Staging, Region.UsEast4, Region.EuCentral1, Region.UsWest1 };
-        foreach (var r  in regions)
+        foreach (var r in regions)
         {
             MockedHandler
                 .When(r.Value.ToString())

--- a/visual-dotnet/SauceLabs.Visual.Tests/BuildFactoryTest.cs
+++ b/visual-dotnet/SauceLabs.Visual.Tests/BuildFactoryTest.cs
@@ -38,7 +38,8 @@ public class BuildFactoryTest
             Convert.ToBase64String(Encoding.ASCII.GetBytes($"{_username}:{_accessKey}"));
         var regions = new[] { Region.Staging, Region.UsEast4, Region.EuCentral1, Region.UsWest1 };
         // BackendDefinitionBehavior.Always;
-        foreach (var r in regions){
+        foreach (var r in regions)
+        {
             MockedHandler
                 .When(r.Value.ToString())
                 .WithHeaders($"Authorization: Basic {base64EncodedAuthenticationString}")

--- a/visual-dotnet/SauceLabs.Visual.Tests/BuildFactoryTest.cs
+++ b/visual-dotnet/SauceLabs.Visual.Tests/BuildFactoryTest.cs
@@ -37,7 +37,7 @@ public class BuildFactoryTest
         var base64EncodedAuthenticationString =
             Convert.ToBase64String(Encoding.ASCII.GetBytes($"{_username}:{_accessKey}"));
         var regions = new[] { Region.Staging, Region.UsEast4, Region.EuCentral1, Region.UsWest1 };
-        foreach (var r in regions)
+        foreach (var r  in regions)
         {
             MockedHandler
                 .When(r.Value.ToString())

--- a/visual-dotnet/SauceLabs.Visual.Tests/BuildFactoryTest.cs
+++ b/visual-dotnet/SauceLabs.Visual.Tests/BuildFactoryTest.cs
@@ -37,7 +37,6 @@ public class BuildFactoryTest
         var base64EncodedAuthenticationString =
             Convert.ToBase64String(Encoding.ASCII.GetBytes($"{_username}:{_accessKey}"));
         var regions = new[] { Region.Staging, Region.UsEast4, Region.EuCentral1, Region.UsWest1 };
-        // BackendDefinitionBehavior.Always;
         foreach (var r in regions)
         {
             MockedHandler

--- a/visual-dotnet/SauceLabs.Visual.Tests/BuildFactoryTest.cs
+++ b/visual-dotnet/SauceLabs.Visual.Tests/BuildFactoryTest.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using GraphQL.Client.Serializer.Newtonsoft;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using RichardSzalay.MockHttp;
+using SauceLabs.Visual.GraphQL;
+using SauceLabs.Visual.Models;
+using SauceLabs.Visual.Tests.Utils;
+
+namespace SauceLabs.Visual.Tests;
+
+public class BuildFactoryTest
+{
+    MockHttpMessageHandler MockedHandler;
+    private const string _username = "dummy-username";
+    private const string _accessKey = "dummy-key";
+
+    [SetUp]
+    public void Setup()
+    {
+        MockedHandler = new MockHttpMessageHandler();
+
+        var createHandler = () =>
+        {
+            var id = RandomString(32);
+            var content = new VisualBuild(id, $"http://dummy/test/{id}", BuildMode.Running);
+            var resp = new HttpResponseMessage(HttpStatusCode.OK);
+            resp.Content = new ReadOnlyMemoryContent(ToResult(content));
+            resp.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            return Task.FromResult(resp);
+        };
+
+        var base64EncodedAuthenticationString =
+            Convert.ToBase64String(Encoding.ASCII.GetBytes($"{_username}:{_accessKey}"));
+        var regions = new[] { Region.Staging, Region.UsEast4, Region.EuCentral1, Region.UsWest1 };
+        // BackendDefinitionBehavior.Always;
+        foreach (var r in regions){
+            MockedHandler
+                .When(r.Value.ToString())
+                .WithHeaders($"Authorization: Basic {base64EncodedAuthenticationString}")
+                .WithPartialContent($"\"operationName\":\"{CreateBuildMutation.OperationName}\"")
+                .Respond(createHandler);
+            MockedHandler
+                .When(r.Value.ToString())
+                .WithHeaders($"Authorization: Basic {base64EncodedAuthenticationString}")
+                .WithPartialContent($"\"operationName\":\"{FinishBuildMutation.OperationName}\"")
+                .Respond(createHandler);
+        }
+        MockedHandler.Fallback.Throw(new InvalidOperationException("No matching mock handler"));
+    }
+
+    [TearDown]
+    public void Cleanup()
+    {
+        MockedHandler.Dispose();
+    }
+
+    private string RandomString(int length)
+    {
+        const string chars = "abcdef0123456789";
+        return new string(Enumerable.Repeat(chars, length).Select(s => s[Random.Shared.Next(s.Length)]).ToArray());
+    }
+
+    private byte[] ToResult(object o)
+    {
+        var nestedContent = new
+        {
+            Data = new
+            {
+                Result = o
+            },
+        };
+        return Encoding.ASCII.GetBytes(JsonConvert.SerializeObject(nestedContent));
+    }
+
+    [Test]
+    public async Task BuildFactory_ReturnSameBuildWhenSameRegion()
+    {
+        var api = new VisualApi(Region.Staging, _username, _accessKey, MockedHandler.ToHttpClient());
+        var build1 = await BuildFactory.Get(api, new CreateBuildOptions());
+        var build2 = await BuildFactory.Get(api, new CreateBuildOptions());
+        Assert.AreEqual(build1, build2);
+    }
+
+    [Test]
+    public async Task BuildFactory_ReturnDifferentBuildWhenDifferentRegion()
+    {
+        var api1 = new VisualApi(Region.Staging, _username, _accessKey, MockedHandler.ToHttpClient());
+        var api2 = new VisualApi(Region.UsEast4, _username, _accessKey, MockedHandler.ToHttpClient());
+        var build1 = await BuildFactory.Get(api1, new CreateBuildOptions());
+        var build2 = await BuildFactory.Get(api2, new CreateBuildOptions());
+        Assert.AreNotEqual(build1, build2);
+    }
+}

--- a/visual-dotnet/SauceLabs.Visual.Tests/BuildFactoryTest.cs
+++ b/visual-dotnet/SauceLabs.Visual.Tests/BuildFactoryTest.cs
@@ -1,18 +1,15 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
-using GraphQL.Client.Serializer.Newtonsoft;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using RichardSzalay.MockHttp;
 using SauceLabs.Visual.GraphQL;
 using SauceLabs.Visual.Models;
-using SauceLabs.Visual.Tests.Utils;
 
 namespace SauceLabs.Visual.Tests;
 

--- a/visual-dotnet/SauceLabs.Visual.Tests/VisualApiTest.cs
+++ b/visual-dotnet/SauceLabs.Visual.Tests/VisualApiTest.cs
@@ -12,7 +12,7 @@ namespace SauceLabs.Visual.Tests;
 
 public class VisualApiTest
 {
-    internal VisualApi<MockedWebDriver>? Api { get; set; }
+    internal VisualApi? Api { get; set; }
     internal MockedWebDriver? WdMock { get; set; }
     internal MockHttpMessageHandler? MockedHandler { get; set; }
 
@@ -27,7 +27,7 @@ public class VisualApiTest
 
         var caps = new MockedCapabilities(new Dictionary<string, object> { { "jobUuid", _jobUuid } });
         WdMock = new MockedWebDriver(caps, _jobUuid);
-        Api = new VisualApi<MockedWebDriver>(WdMock, Region.Staging, _username, _accessKey, MockedHandler.ToHttpClient());
+        Api = new VisualApi(Region.Staging, _username, _accessKey, MockedHandler.ToHttpClient());
     }
 
     [Test]

--- a/visual-dotnet/SauceLabs.Visual/ApiBuildPair.cs
+++ b/visual-dotnet/SauceLabs.Visual/ApiBuildPair.cs
@@ -1,0 +1,14 @@
+namespace SauceLabs.Visual
+{
+    public class ApiBuildPair
+    {
+        internal VisualBuild Build { get; }
+        internal VisualApi Api { get; }
+
+        internal ApiBuildPair(VisualApi api, VisualBuild build)
+        {
+            Build = build;
+            Api = api;
+        }
+    }
+}

--- a/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
+++ b/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
+++ b/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
@@ -8,24 +8,24 @@ namespace SauceLabs.Visual
 {
     internal static class BuildFactory
     {
-        private static readonly Dictionary<Region, VisualBuild> _builds = new Dictionary<Region, VisualBuild>();
+        private static readonly Dictionary<string, VisualBuild> _builds = new Dictionary<string, VisualBuild>();
 
         internal static async Task<VisualBuild> Get(VisualClient client, CreateBuildOptions options)
         {
             // Check if there is already a build for the current region.
-            if (_builds.TryGetValue(client.Api.Region, out var build))
+            if (_builds.TryGetValue(client.Api.Region.Name, out var build))
             {
                 return build;
             }
 
             var createdBuild = await Create(client, options);
-            _builds[client.Api.Region] = createdBuild;
+            _builds[client.Api.Region.Name] = createdBuild;
             return createdBuild;
         }
 
         private static void Disregard(VisualBuild build)
         {
-            Region? key = null;
+            string? key = null;
             var enumerator = _builds.GetEnumerator();
             while (enumerator.MoveNext())
             {

--- a/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
+++ b/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
@@ -29,19 +29,7 @@ namespace SauceLabs.Visual
         /// <param name="build">the build to remove</param>
         private static void Disregard(VisualBuild build)
         {
-            string? key = null;
-            var enumerator = Builds.GetEnumerator();
-            while (enumerator.MoveNext())
-            {
-                if (enumerator.Current.Value != build)
-                {
-                    continue;
-                }
-                key = enumerator.Current.Key;
-                break;
-            }
-            enumerator.Dispose();
-
+            var key = (from entry in Builds where entry.Value == build select entry.Key).FirstOrDefault();
             if (key != null)
             {
                 Builds.Remove(key);

--- a/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
+++ b/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
@@ -50,13 +50,37 @@ namespace SauceLabs.Visual
             var key = FindRegionByBuild(build);
             if (key != null)
             {
-                var entry = Builds[key];
+                await Close(key, Builds[key]);
+            }
+        }
+
+        /// <summary>
+        /// <c>Close</c> finishes and forget about <c>build</c>
+        /// </summary>
+        /// <param name="region">the build to finish</param>
+        /// <param name="entry">the api/build pair</param>
+        private static async Task Close(string region, ApiBuildPair entry)
+        {
+            if (!entry.Build.IsExternal)
+            {
                 if (!entry.Build.IsExternal)
                 {
                     await entry.Api.FinishBuild(entry.Build.Id);
                 }
+            }
+            Builds.Remove(region);
+            entry.Api.Dispose();
+        }
 
-                Builds.Remove(key);
+        /// <summary>
+        /// <c>CloseBuilds</c> closes all build that are still open.
+        /// </summary>
+        internal static async Task CloseBuilds()
+        {
+            var regions = Builds.Keys;
+            foreach (var region in regions)
+            {
+                await Close(region, Builds[region]);
             }
         }
 
@@ -97,24 +121,6 @@ namespace SauceLabs.Visual
             catch (VisualClientException)
             {
                 return null;
-            }
-        }
-
-        /// <summary>
-        /// <c>CloseBuilds</c> closes all build that are still open.
-        /// </summary>
-        internal static async Task CloseBuilds()
-        {
-            var regions = Builds.Keys.ToArray();
-            foreach (var region in regions)
-            {
-                var entry = Builds[region];
-                if (!entry.Build.IsExternal)
-                {
-                    await entry.Api.FinishBuild(entry.Build.Id);
-                }
-                entry.Api.Dispose();
-                Builds.Remove(region);
             }
         }
 

--- a/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
+++ b/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
@@ -10,6 +10,14 @@ namespace SauceLabs.Visual
     {
         private static readonly Dictionary<string, ApiBuildPair> Builds = new Dictionary<string, ApiBuildPair>();
 
+        /// <summary>
+        /// <c>Get</c> returns the build matching with the requested region.
+        /// If none is available, it returns a newly created build with <c>options</c>.
+        /// It will also clone the input <c>api</c> to be able to close the build later.
+        /// </summary>
+        /// <param name="api">the api to use to create build</param>
+        /// <param name="options">the options to use when creating the build</param>
+        /// <returns></returns>
         internal static async Task<VisualBuild> Get(VisualApi api, CreateBuildOptions options)
         {
             // Check if there is already a build for the current region.
@@ -23,11 +31,20 @@ namespace SauceLabs.Visual
             return createdBuild;
         }
 
+        /// <summary>
+        /// <c>FindRegionByBuild</c> returns the region matching the passed build.
+        /// </summary>
+        /// <param name="build"></param>
+        /// <returns>the matching region name</returns>
         private static string? FindRegionByBuild(VisualBuild build)
         {
             return (from entry in Builds where entry.Value.Build == build select entry.Key).FirstOrDefault();
         }
 
+        /// <summary>
+        /// <c>Close</c> finishes and forget about <c>build</c>
+        /// </summary>
+        /// <param name="build">the build to finish</param>
         internal static async Task Close(VisualBuild build)
         {
             var key = FindRegionByBuild(build);

--- a/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
+++ b/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
@@ -98,13 +98,16 @@ namespace SauceLabs.Visual
         /// </summary>
         internal static async Task CloseBuilds()
         {
-            var builds = Builds.Values.ToArray();
-            foreach (var entry in builds)
+            var regions = Builds.Keys.ToArray();
+            foreach (var region in regions)
             {
+                var entry = Builds[region];
                 if (!entry.Build.IsExternal)
                 {
                     await entry.Api.FinishBuild(entry.Build.Id);
                 }
+                entry.Api.Dispose();
+                Builds.Remove(region);
             }
         }
 

--- a/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
+++ b/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using SauceLabs.Visual.GraphQL;
+using SauceLabs.Visual.Utils;
+
+namespace SauceLabs.Visual
+{
+    internal static class BuildFactory
+    {
+        private static readonly Dictionary<Region, VisualBuild> _builds = new Dictionary<Region, VisualBuild>();
+
+        internal static async Task<VisualBuild> Get(VisualClient client, CreateBuildOptions options)
+        {
+            // Check if there is already a build for the current region.
+            if (_builds.TryGetValue(client.Api.Region, out var build))
+            {
+                return build;
+            }
+
+            var createdBuild = await Create(client, options);
+            _builds[client.Api.Region] = createdBuild;
+            return createdBuild;
+        }
+
+        private static void Disregard(VisualBuild build)
+        {
+            Region? key = null;
+            var enumerator = _builds.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                if (enumerator.Current.Value != build)
+                {
+                    continue;
+                }
+                key = enumerator.Current.Key;
+                break;
+            }
+            enumerator.Dispose();
+
+            if (key != null)
+            {
+                _builds.Remove(key);
+            }
+        }
+
+        public static async Task CloseBuilds()
+        {
+            var builds = _builds.Values.ToArray();
+            foreach (var build in builds)
+            {
+                if (build.Close != null)
+                {
+                    await build.Close();
+                }
+            }
+        }
+
+        /// <summary>
+        /// <c>CreateBuild</c> creates a new Visual build.
+        /// </summary>
+        /// <param name="client">the client used for the build creation</param>
+        /// <param name="options">the options for the build creation</param>
+        /// <returns>a <c>VisualBuild</c> instance</returns>
+        private static async Task<VisualBuild> Create(VisualClient client, CreateBuildOptions options)
+        {
+            var build = await GetEffectiveBuild(client, EnvVars.BuildId, EnvVars.CustomId);
+            if (build != null)
+            {
+                if (!build.IsRunning())
+                {
+                    throw new VisualClientException($"build {build.Id} is not RUNNING");
+                }
+
+                build.IsExternal = true;
+                build.Close = async () => Disregard(build);
+                return build;
+            }
+
+            options.CustomId ??= EnvVars.CustomId;
+            var result = (await client.Api.CreateBuild(new CreateBuildIn
+            {
+                Name = options.Name,
+                Project = options.Project,
+                Branch = options.Branch,
+                CustomId = options.CustomId,
+                DefaultBranch = options.DefaultBranch,
+            })).EnsureValidResponse();
+
+            build = new VisualBuild(result.Result.Id, result.Result.Url, result.Result.Mode)
+            {
+                IsExternal = false,
+            };
+
+            var copiedApi = client.Api.Clone();
+            build.Close = async () =>
+            {
+                await copiedApi.FinishBuild(build.Id);
+                Disregard(build);
+            };
+            return build;
+        }
+
+        private static async Task<VisualBuild?> GetEffectiveBuild(VisualClient client, string? buildId, string? customId)
+        {
+            if (!StringUtils.IsNullOrEmpty(buildId))
+            {
+                return await client.FindBuildById(buildId!.Trim());
+            }
+
+            if (!StringUtils.IsNullOrEmpty(customId))
+            {
+                return await client.FindBuildByCustomId(customId!.Trim());
+            }
+            return null;
+        }
+    }
+}

--- a/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
+++ b/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
@@ -8,25 +8,25 @@ namespace SauceLabs.Visual
 {
     internal static class BuildFactory
     {
-        private static readonly Dictionary<string, VisualBuild> _builds = new Dictionary<string, VisualBuild>();
+        private static readonly Dictionary<string, VisualBuild> Builds = new Dictionary<string, VisualBuild>();
 
         internal static async Task<VisualBuild> Get(VisualClient client, CreateBuildOptions options)
         {
             // Check if there is already a build for the current region.
-            if (_builds.TryGetValue(client.Api.Region.Name, out var build))
+            if (Builds.TryGetValue(client.Api.Region.Name, out var build))
             {
                 return build;
             }
 
             var createdBuild = await Create(client, options);
-            _builds[client.Api.Region.Name] = createdBuild;
+            Builds[client.Api.Region.Name] = createdBuild;
             return createdBuild;
         }
 
         private static void Disregard(VisualBuild build)
         {
             string? key = null;
-            var enumerator = _builds.GetEnumerator();
+            var enumerator = Builds.GetEnumerator();
             while (enumerator.MoveNext())
             {
                 if (enumerator.Current.Value != build)
@@ -40,7 +40,7 @@ namespace SauceLabs.Visual
 
             if (key != null)
             {
-                _builds.Remove(key);
+                Builds.Remove(key);
             }
         }
 
@@ -89,7 +89,7 @@ namespace SauceLabs.Visual
         /// </summary>
         internal static async Task CloseBuilds()
         {
-            var builds = _builds.Values.ToArray();
+            var builds = Builds.Values.ToArray();
             foreach (var build in builds)
             {
                 if (build.Close != null)

--- a/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
+++ b/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
@@ -38,7 +38,7 @@ namespace SauceLabs.Visual
         /// <returns>the matching region name</returns>
         private static string? FindRegionByBuild(VisualBuild build)
         {
-            return (from entry in Builds where entry.Value.Build == build select entry.Key).FirstOrDefault();
+            return Builds.Where(n => n.Value.Build == build).Select(n => n.Key).FirstOrDefault();
         }
 
         /// <summary>
@@ -63,10 +63,7 @@ namespace SauceLabs.Visual
         {
             if (!entry.Build.IsExternal)
             {
-                if (!entry.Build.IsExternal)
-                {
-                    await entry.Api.FinishBuild(entry.Build.Id);
-                }
+                await entry.Api.FinishBuild(entry.Build.Id);
             }
             Builds.Remove(region);
             entry.Api.Dispose();

--- a/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
+++ b/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
@@ -51,20 +51,11 @@ namespace SauceLabs.Visual
             if (key != null)
             {
                 var entry = Builds[key];
-                await entry.Api.FinishBuild(entry.Build.Id);
-                Builds.Remove(key);
-            }
-        }
+                if (!entry.Build.IsExternal)
+                {
+                    await entry.Api.FinishBuild(entry.Build.Id);
+                }
 
-        /// <summary>
-        /// <c>Disregard</c> removes the build from the known builds.
-        /// </summary>
-        /// <param name="build">the build to remove</param>
-        private static void Disregard(VisualBuild build)
-        {
-            var key = FindRegionByBuild(build);
-            if (key != null)
-            {
                 Builds.Remove(key);
             }
         }

--- a/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
+++ b/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
@@ -10,16 +10,16 @@ namespace SauceLabs.Visual
     {
         private static readonly Dictionary<string, VisualBuild> Builds = new Dictionary<string, VisualBuild>();
 
-        internal static async Task<VisualBuild> Get(VisualClient client, CreateBuildOptions options)
+        internal static async Task<VisualBuild> Get(VisualApi api, CreateBuildOptions options)
         {
             // Check if there is already a build for the current region.
-            if (Builds.TryGetValue(client.Api.Region.Name, out var build))
+            if (Builds.TryGetValue(api.Region.Name, out var build))
             {
                 return build;
             }
 
-            var createdBuild = await Create(client, options);
-            Builds[client.Api.Region.Name] = createdBuild;
+            var createdBuild = await Create(api, options);
+            Builds[api.Region.Name] = createdBuild;
             return createdBuild;
         }
 
@@ -109,9 +109,9 @@ namespace SauceLabs.Visual
         /// <param name="client">the client used for the build creation</param>
         /// <param name="options">the options for the build creation</param>
         /// <returns>a <c>VisualBuild</c> instance</returns>
-        private static async Task<VisualBuild> Create(VisualClient client, CreateBuildOptions options)
+        private static async Task<VisualBuild> Create(VisualApi api, CreateBuildOptions options)
         {
-            var build = await GetEffectiveBuild(client.Api, EnvVars.BuildId, EnvVars.CustomId);
+            var build = await GetEffectiveBuild(api, EnvVars.BuildId, EnvVars.CustomId);
             if (build != null)
             {
                 if (!build.IsRunning())
@@ -125,7 +125,7 @@ namespace SauceLabs.Visual
             }
 
             options.CustomId ??= EnvVars.CustomId;
-            var result = (await client.Api.CreateBuild(new CreateBuildIn
+            var result = (await api.CreateBuild(new CreateBuildIn
             {
                 Name = options.Name,
                 Project = options.Project,
@@ -136,10 +136,10 @@ namespace SauceLabs.Visual
 
             build = new VisualBuild(result.Result.Id, result.Result.Url, result.Result.Mode)
             {
-                IsExternal = false,
+                IsExternal = false
             };
 
-            var copiedApi = client.Api.Clone();
+            var copiedApi = api.Clone();
             build.Close = async () =>
             {
                 await copiedApi.FinishBuild(build.Id);

--- a/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
+++ b/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
@@ -23,6 +23,10 @@ namespace SauceLabs.Visual
             return createdBuild;
         }
 
+        /// <summary>
+        /// <c>Disregard</c> removes the build from the known builds.
+        /// </summary>
+        /// <param name="build">the build to remove</param>
         private static void Disregard(VisualBuild build)
         {
             string? key = null;

--- a/visual-dotnet/SauceLabs.Visual/Region.cs
+++ b/visual-dotnet/SauceLabs.Visual/Region.cs
@@ -8,17 +8,20 @@ namespace SauceLabs.Visual
     /// </summary>
     public class Region
     {
-        private Region(Uri value)
+        private Region(string name, Uri value)
         {
             Value = value;
+            Name = name;
         }
 
-        private Region(string value)
+        private Region(string name, string value)
         {
+            Name = name;
             Value = new Uri(value);
         }
 
         public Uri Value { get; }
+        public string Name { get; }
 
         public override string ToString()
         {
@@ -43,9 +46,9 @@ namespace SauceLabs.Visual
             };
         }
 
-        public static Region UsWest1 => new Region("https://api.us-west-1.saucelabs.com/v1/visual/graphql");
-        public static Region UsEast4 => new Region("https://api.us-east-4.saucelabs.com/v1/visual/graphql");
-        public static Region EuCentral1 => new Region("https://api.eu-central-1.saucelabs.com/v1/visual/graphql");
-        public static Region Staging => new Region("https://api.staging.saucelabs.net/v1/visual/graphql");
+        public static Region UsWest1 => new Region("us-west-1", "https://api.us-west-1.saucelabs.com/v1/visual/graphql");
+        public static Region UsEast4 => new Region("us-east-4", "https://api.us-east-4.saucelabs.com/v1/visual/graphql");
+        public static Region EuCentral1 => new Region("eu-central-1", "https://api.eu-central-1.saucelabs.com/v1/visual/graphql");
+        public static Region Staging => new Region("staging", "https://api.staging.saucelabs.net/v1/visual/graphql");
     }
 }

--- a/visual-dotnet/SauceLabs.Visual/VisualApi.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualApi.cs
@@ -14,7 +14,7 @@ namespace SauceLabs.Visual
 {
     internal class VisualApi : IDisposable
     {
-        private readonly Region _region;
+        internal readonly Region Region;
         private readonly string _username;
         private readonly string _accessKey;
         private readonly GraphQLHttpClient _graphQlClient;
@@ -28,7 +28,7 @@ namespace SauceLabs.Visual
                     "Invalid SauceLabs credentials. Please check your SauceLabs username and access key at https://app.saucelabs.com/user-setting");
             }
 
-            _region = region;
+            Region = region;
             _username = username.Trim();
             _accessKey = accessKey.Trim();
 
@@ -122,7 +122,7 @@ namespace SauceLabs.Visual
 
         internal VisualApi Clone()
         {
-            return new VisualApi(_region, _username, _accessKey);
+            return new VisualApi(Region, _username, _accessKey);
         }
     }
 }

--- a/visual-dotnet/SauceLabs.Visual/VisualApi.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualApi.cs
@@ -7,19 +7,19 @@ using GraphQL;
 using GraphQL.Client.Http;
 using GraphQL.Client.Serializer.Newtonsoft;
 using Newtonsoft.Json;
-using OpenQA.Selenium;
 using SauceLabs.Visual.GraphQL;
 using SauceLabs.Visual.Utils;
 
 namespace SauceLabs.Visual
 {
-    internal class VisualApi<T> : IDisposable where T : IHasCapabilities, IHasSessionId
+    internal class VisualApi : IDisposable
     {
+        private readonly Region _region;
         private readonly string _username;
         private readonly string _accessKey;
         private readonly GraphQLHttpClient _graphQlClient;
 
-        public VisualApi(T webdriver, Region region, string username, string accessKey, HttpClient? httpClient = null)
+        public VisualApi(Region region, string username, string accessKey, HttpClient? httpClient = null)
         {
 
             if (StringUtils.IsNullOrEmpty(username) || StringUtils.IsNullOrEmpty(accessKey))
@@ -27,6 +27,8 @@ namespace SauceLabs.Visual
                 throw new VisualClientException(
                     "Invalid SauceLabs credentials. Please check your SauceLabs username and access key at https://app.saucelabs.com/user-setting");
             }
+
+            _region = region;
             _username = username.Trim();
             _accessKey = accessKey.Trim();
 
@@ -116,6 +118,11 @@ namespace SauceLabs.Visual
         public void Dispose()
         {
             _graphQlClient.Dispose();
+        }
+
+        internal VisualApi Clone()
+        {
+            return new VisualApi(_region, _username, _accessKey);
         }
     }
 }

--- a/visual-dotnet/SauceLabs.Visual/VisualBuild.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualBuild.cs
@@ -15,7 +15,7 @@ namespace SauceLabs.Visual
         public BuildMode Mode { get; internal set; }
 
         internal bool IsExternal { get; set; } = false;
-        internal Func<Task>? Closer;
+        internal Func<Task>? Close;
 
         internal VisualBuild(string id, string url, BuildMode mode)
         {

--- a/visual-dotnet/SauceLabs.Visual/VisualBuild.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualBuild.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading.Tasks;
 using SauceLabs.Visual.Models;
 
 namespace SauceLabs.Visual
@@ -11,6 +13,9 @@ namespace SauceLabs.Visual
         public string Url { get; internal set; }
 
         public BuildMode Mode { get; internal set; }
+
+        internal bool IsExternal { get; set; } = false;
+        internal Func<Task>? Closer;
 
         internal VisualBuild(string id, string url, BuildMode mode)
         {

--- a/visual-dotnet/SauceLabs.Visual/VisualBuild.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualBuild.cs
@@ -14,6 +14,9 @@ namespace SauceLabs.Visual
 
         public BuildMode Mode { get; internal set; }
 
+        /// <summary>
+        /// <c>IsExternal</c> represents if the build lifecycle is managed outside of the current context.
+        /// </summary>
         internal bool IsExternal { get; set; } = false;
 
         internal VisualBuild(string id, string url, BuildMode mode)

--- a/visual-dotnet/SauceLabs.Visual/VisualBuild.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualBuild.cs
@@ -15,7 +15,6 @@ namespace SauceLabs.Visual
         public BuildMode Mode { get; internal set; }
 
         internal bool IsExternal { get; set; } = false;
-        internal Func<Task>? Close;
 
         internal VisualBuild(string id, string url, BuildMode mode)
         {

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
@@ -26,7 +26,10 @@ namespace SauceLabs.Visual
         /// </summary>
         public string? TestName { get; set; }
 
-        private bool HasCompleteTestContext() => !string.IsNullOrEmpty(SuiteName) & !string.IsNullOrEmpty(TestName);
+        private bool HasCompleteTestContext()
+        {
+            return string.IsNullOrEmpty(SuiteName) & !string.IsNullOrEmpty(TestName);
+        }
 
         internal void EnsureTestContextIsPopulated(string callerMemberName, string? previousSuiteName)
         {

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
@@ -30,7 +30,7 @@ namespace SauceLabs.Visual
 
         internal void EnsureTestContextIsPopulated(string callerMemberName, string? previousSuiteName)
         {
-            if (string.IsNullOrEmpty(callerMemberName) || HasIncompleteTestContext())
+            if (string.IsNullOrEmpty(callerMemberName) || !HasIncompleteTestContext())
             {
                 return;
             }

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
@@ -26,11 +26,11 @@ namespace SauceLabs.Visual
         /// </summary>
         public string? TestName { get; set; }
 
-        private bool HasIncompleteTestContext() => string.IsNullOrEmpty(SuiteName) || string.IsNullOrEmpty(TestName);
+        private bool HasCompleteTestContext() => !string.IsNullOrEmpty(SuiteName) & !string.IsNullOrEmpty(TestName);
 
         internal void EnsureTestContextIsPopulated(string callerMemberName, string? previousSuiteName)
         {
-            if (string.IsNullOrEmpty(callerMemberName) || !HasIncompleteTestContext())
+            if (string.IsNullOrEmpty(callerMemberName) || HasCompleteTestContext())
             {
                 return;
             }

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -171,7 +171,7 @@ namespace SauceLabs.Visual
         }
 
         /// <summary>
-        /// <c>CloseBuilds</c> closes all builds that have been open during that test session. No action should be made after calling <c>CloseBuilds</c>.
+        /// <c>Finish</c> ensures that all known build are closed. No action should be made after calling <c>Finish</c>.
         /// </summary>
         public static async Task Finish()
         {

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -115,64 +115,6 @@ namespace SauceLabs.Visual
         }
 
         /// <summary>
-        /// <c>FindBuildById</c> returns the build identified by <c>buildId</c>
-        /// </summary>
-        /// <param name="buildId"></param>
-        /// <returns>the matching build</returns>
-        /// <exception cref="VisualClientException">when build is not existing or has an invalid state</exception>
-        internal async Task<VisualBuild> FindBuildById(string buildId)
-        {
-            try
-            {
-                var build = (await Api.Build(buildId)).EnsureValidResponse().Result;
-                return new VisualBuild(build.Id, build.Url, build.Mode);
-            }
-            catch (VisualClientException)
-            {
-                throw new VisualClientException($@"build {buildId} was not found");
-            }
-        }
-
-        /// <summary>
-        /// <c>FindBuildByCustomId</c> returns the build identified by <c>customId</c> or null if not found
-        /// </summary>
-        /// <param name="customId"></param>
-        /// <returns>the matching build or null</returns>
-        /// <exception cref="VisualClientException">when build has an invalid state</exception>
-        internal async Task<VisualBuild?> FindBuildByCustomId(string customId)
-        {
-            try
-            {
-                var build = (await Api.BuildByCustomId(customId)).EnsureValidResponse().Result;
-                return new VisualBuild(build.Id, build.Url, build.Mode);
-            }
-            catch (VisualClientException)
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// <c>GetEffectiveBuild</c> tries to find the build matching the criterion provided by the user.
-        /// </summary>
-        /// <param name="buildId"></param>
-        /// <param name="customId"></param>
-        /// <returns></returns>
-        private async Task<VisualBuild?> GetEffectiveBuild(string? buildId, string? customId)
-        {
-            if (!StringUtils.IsNullOrEmpty(buildId))
-            {
-                return await FindBuildById(buildId!.Trim());
-            }
-
-            if (!StringUtils.IsNullOrEmpty(customId))
-            {
-                return await FindBuildByCustomId(customId!.Trim());
-            }
-            return null;
-        }
-
-        /// <summary>
         /// <c>FinishBuild</c> finishes a build
         /// </summary>
         /// <param name="build">the build to finish</param>
@@ -184,9 +126,9 @@ namespace SauceLabs.Visual
         /// <summary>
         /// <c>VisualCheck</c> captures a screenshot and queue it for processing.
         /// </summary>
-        /// <param name="build">the build that will contain the screenshot</param>
         /// <param name="name">the name of the screenshot</param>
         /// <param name="options">the configuration for the screenshot capture and comparison</param>
+        /// <param name="callerMemberName">the member name of the caller (automated) </param>
         /// <returns></returns>
         public Task<string> VisualCheck(string name, VisualCheckOptions? options = null,
             [CallerMemberName] string callerMemberName = "")

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -82,7 +82,7 @@ namespace SauceLabs.Visual
             var metadata = response.EnsureValidResponse();
             _sessionMetadataBlob = metadata.Result.Blob;
 
-            Build = await BuildFactory.Get(this, buildOptions);
+            Build = await BuildFactory.Get(Api, buildOptions);
         }
 
         /// <summary>

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -167,16 +167,13 @@ namespace SauceLabs.Visual
         /// </summary>
         public async Task Cleanup()
         {
-            if (Build.Close != null)
-            {
-                await Build.Close();
-            }
+            await BuildFactory.Close(Build);
         }
 
         /// <summary>
         /// <c>CloseBuilds</c> closes all builds that have been open during that test session. No action should be made after calling <c>CloseBuilds</c>.
         /// </summary>
-        public static async Task CloseBuilds()
+        public static async Task Finish()
         {
             await BuildFactory.CloseBuilds();
         }

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -75,11 +75,11 @@ namespace SauceLabs.Visual
         public static async Task<VisualClient> Create(WebDriver wd, Region region, string username, string accessKey, CreateBuildOptions buildOptions)
         {
             var client = new VisualClient(wd, region, username, accessKey);
-            await client.SetupBuild(region, username, accessKey, buildOptions);
+            await client.SetupBuild(buildOptions);
             return client;
         }
 
-        private async Task SetupBuild(Region region, string username, string accessKey, CreateBuildOptions buildOptions)
+        private async Task SetupBuild(CreateBuildOptions buildOptions)
         {
             var response = await _api.WebDriverSessionInfo(_jobId, _sessionId);
             var metadata = response.EnsureValidResponse();

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -90,7 +90,11 @@ namespace SauceLabs.Visual
                 Build = _sharedBuild;
                 var copiedApi = _api.Clone();
                 var buildId = Build.Id;
-                _sharedBuild.Closer = async () => await copiedApi.FinishBuild(buildId);
+                _sharedBuild.Close = async () =>
+                {
+                    await copiedApi.FinishBuild(buildId);
+                    copiedApi.Dispose();
+                };
                 return;
             }
 
@@ -274,9 +278,9 @@ namespace SauceLabs.Visual
         /// </summary>
         public static async Task Cleanup()
         {
-            if (_sharedBuild?.Closer != null)
+            if (_sharedBuild?.Close != null)
             {
-                await _sharedBuild.Closer();
+                await _sharedBuild.Close();
             }
             _sharedBuild = null;
         }


### PR DESCRIPTION
# One-line summary

> Issue : IRIS-856

## Description

Currently build is created (or loaded) upon creation of the `VisualClient`.
This PR comes to persist the newly created build, thus allowing multiple class to be reported within the same `VisualBuild`.

As a consequence, the `Cleanup` will need to be moved out of the test AfterAll, but to a global AfterAll.

Additionally:
- Fixes a bug in the `TextContext` implementation
- Removes dependency of `VisualApi` to `WebDriver` as it's never used

## Types of Changes

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)

