### PR TITLE
[Python] Extend default GQL timeout

### DIFF
--- a/visual-python/src/saucelabs_visual/client.py
+++ b/visual-python/src/saucelabs_visual/client.py
@@ -28,7 +28,7 @@ class SauceLabsVisual:
 
         region_url = Region.from_name(environ.get("SAUCE_REGION") or 'us-west-1').graphql_endpoint
         transport = AIOHTTPTransport(url=region_url, auth=BasicAuth(username, access_key))
-        self.client = Client(transport=transport)
+        self.client = Client(transport=transport, execute_timeout=90)
 
     def get_client(self) -> Client:
         return self.client


### PR DESCRIPTION
## Description
Extends the default GQL client to match API services.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
