### PR TITLE
bugfix: .Net / NullReferenceException when buildId or customId is not found

### DIFF
--- a/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
+++ b/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
@@ -93,6 +93,11 @@ namespace SauceLabs.Visual
             try
             {
                 var build = (await api.Build(buildId)).EnsureValidResponse().Result;
+                if (build == null)
+                {
+                    throw new VisualClientException("not found");
+                }
+
                 return new VisualBuild(build.Id, build.Url, build.Mode);
             }
             catch (VisualClientException)
@@ -113,6 +118,11 @@ namespace SauceLabs.Visual
             try
             {
                 var build = (await api.BuildByCustomId(customId)).EnsureValidResponse().Result;
+                if (build == null)
+                {
+                    throw new VisualClientException("not found");
+                }
+
                 return new VisualBuild(build.Id, build.Url, build.Mode);
             }
             catch (VisualClientException)

--- a/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
+++ b/visual-dotnet/SauceLabs.Visual/BuildFactory.cs
@@ -95,7 +95,7 @@ namespace SauceLabs.Visual
                 var build = (await api.Build(buildId)).EnsureValidResponse().Result;
                 if (build == null)
                 {
-                    throw new VisualClientException("not found");
+                    throw new VisualClientException($@"build {buildId} was not found");
                 }
 
                 return new VisualBuild(build.Id, build.Url, build.Mode);
@@ -120,7 +120,7 @@ namespace SauceLabs.Visual
                 var build = (await api.BuildByCustomId(customId)).EnsureValidResponse().Result;
                 if (build == null)
                 {
-                    throw new VisualClientException("not found");
+                    throw new VisualClientException($@"build identified by {customId} was not found");
                 }
 
                 return new VisualBuild(build.Id, build.Url, build.Mode);


### PR DESCRIPTION
Fixes `NullReferenceException` when buildId or customId is not found.

> Issue : IRIS-924

## Description

`NullReferenceException` occurs when `buildId` or `customId` specified is invalid.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)

## Tasks
