### PR TITLE
.NET: Enhance VisualCheckOptions

### DIFF
--- a/visual-dotnet/SauceLabs.Visual/Utils/DiffingOptionsInHelper.cs
+++ b/visual-dotnet/SauceLabs.Visual/Utils/DiffingOptionsInHelper.cs
@@ -7,7 +7,7 @@ namespace SauceLabs.Visual.Utils
 {
     public static class DiffingOptionsInHelper
     {
-        private static DiffingOptionsIn SetOptions(DiffingOptionsIn opts, DiffingOption flags, bool value)
+        internal static DiffingOptionsIn SetOptions(DiffingOptionsIn opts, DiffingOption flags, bool value)
         {
             if (flags.HasFlag(DiffingOption.Content))
             {

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckDiffingOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckDiffingOptions.cs
@@ -24,12 +24,12 @@ namespace SauceLabs.Visual
             _flags = flags;
         }
 
-        public VisualCheckDiffingOptions EnableOnly(DiffingOption flags)
+        public static VisualCheckDiffingOptions EnableOnly(DiffingOption flags)
         {
             return new VisualCheckDiffingOptions(DiffingOptionMode.EnableOnly, flags);
         }
 
-        public VisualCheckDiffingOptions DisableOnly(DiffingOption flags)
+        public static VisualCheckDiffingOptions DisableOnly(DiffingOption flags)
         {
             return new VisualCheckDiffingOptions(DiffingOptionMode.DisableOnly, flags);
         }

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckDiffingOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckDiffingOptions.cs
@@ -24,11 +24,19 @@ namespace SauceLabs.Visual
             _flags = flags;
         }
 
+        /// <summary>
+        /// <c>EnableOnly</c> sets which change types to check for.
+        /// Only <c>BALANCED</c> engine is compatible.
+        /// </summary>
         public static VisualCheckDiffingOptions EnableOnly(DiffingOption flags)
         {
             return new VisualCheckDiffingOptions(DiffingOptionMode.EnableOnly, flags);
         }
 
+        /// <summary>
+        /// <c>DisableOnly</c> sets which change types to ignore.
+        /// Only <c>BALANCED</c> engine is compatible.
+        /// </summary>
         public static VisualCheckDiffingOptions DisableOnly(DiffingOption flags)
         {
             return new VisualCheckDiffingOptions(DiffingOptionMode.DisableOnly, flags);

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckDiffingOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckDiffingOptions.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics;
+using System.Linq;
+using OpenQA.Selenium;
+using SauceLabs.Visual.GraphQL;
+using SauceLabs.Visual.Models;
+using SauceLabs.Visual.Utils;
+
+namespace SauceLabs.Visual
+{
+    public class VisualCheckDiffingOptions
+    {
+        private enum DiffingOptionMode
+        {
+            EnableOnly,
+            DisableOnly
+        }
+
+        private readonly DiffingOptionMode _mode;
+        private readonly DiffingOption _flags;
+
+        private VisualCheckDiffingOptions(DiffingOptionMode mode, DiffingOption flags)
+        {
+            _mode = mode;
+            _flags = flags;
+        }
+
+        public VisualCheckDiffingOptions EnableOnly(DiffingOption flags)
+        {
+            return new VisualCheckDiffingOptions(DiffingOptionMode.EnableOnly, flags);
+        }
+
+        public VisualCheckDiffingOptions DisableOnly(DiffingOption flags)
+        {
+            return new VisualCheckDiffingOptions(DiffingOptionMode.DisableOnly, flags);
+        }
+
+        internal DiffingOptionsIn ToDiffingOptionsIn()
+        {
+            DiffingOptionsIn options;
+            if (_mode == DiffingOptionMode.EnableOnly)
+            {
+                options = new DiffingOptionsIn(false);
+                options = DiffingOptionsInHelper.SetOptions(options, _flags, true);
+            }
+            else
+            {
+                options = new DiffingOptionsIn(true);
+                options = DiffingOptionsInHelper.SetOptions(options, _flags, false);
+                return options;
+            }
+            return options;
+        }
+    }
+}

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckDiffingOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckDiffingOptions.cs
@@ -26,7 +26,7 @@ namespace SauceLabs.Visual
 
         /// <summary>
         /// <c>EnableOnly</c> sets which change types to check for.
-        /// Only <c>BALANCED</c> engine is compatible.
+        /// Compatible only with <c>DiffingMethod.Balanced</c>
         /// </summary>
         public static VisualCheckDiffingOptions EnableOnly(DiffingOption flags)
         {
@@ -35,7 +35,7 @@ namespace SauceLabs.Visual
 
         /// <summary>
         /// <c>DisableOnly</c> sets which change types to ignore.
-        /// Only <c>BALANCED</c> engine is compatible.
+        /// Compatible only with <c>DiffingMethod.Balanced</c>
         /// </summary>
         public static VisualCheckDiffingOptions DisableOnly(DiffingOption flags)
         {

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckDiffingOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckDiffingOptions.cs
@@ -39,14 +39,11 @@ namespace SauceLabs.Visual
             DiffingOptionsIn options;
             if (_mode == DiffingOptionMode.EnableOnly)
             {
-                options = new DiffingOptionsIn(false);
-                options = DiffingOptionsInHelper.SetOptions(options, _flags, true);
+                options = DiffingOptionsInHelper.SetOptions(new DiffingOptionsIn(false), _flags, true);
             }
             else
             {
-                options = new DiffingOptionsIn(true);
-                options = DiffingOptionsInHelper.SetOptions(options, _flags, false);
-                return options;
+                options = DiffingOptionsInHelper.SetOptions(new DiffingOptionsIn(true), _flags, false);
             }
             return options;
         }

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
@@ -20,14 +20,9 @@ namespace SauceLabs.Visual
         public string? ClipSelector { get; set; }
 
         /// <summary>
-        /// <c>EnableOnly</c> allows to specify which changes to consider globaly.
+        /// <c>DiffingOptions</c> set which kind of changes should be considered.
         /// </summary>
-        public DiffingOption? EnableOnly { get; set; }
-
-        /// <summary>
-        /// <c>Disable</c> allows to specify which changes to ignore globally.
-        /// </summary>
-        public DiffingOption? DisableOnly { get; set; }
+        public VisualCheckDiffingOptions? DiffingOptions { get; set; }
 
         /// <summary>
         /// <c>Regions</c> allows to specify what kind of checks needs to be done in a specific region.

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -165,7 +165,7 @@ namespace SauceLabs.Visual
                 suiteName: options.SuiteName,
                 testName: options.TestName,
                 fullPageConfig: fullPageConfigIn,
-                diffingOptions: DiffingOptionsInHelper.CreateFromEnableOnlyDisable(options.EnableOnly, options.DisableOnly)
+                diffingOptions: options.DiffingOptions?.ToDiffingOptionsIn()
             ))).EnsureValidResponse();
             result.Result.Diffs.Nodes.ToList().ForEach(d => _screenshotIds.Add(d.Id));
             return result.Result.Id;


### PR DESCRIPTION
# One-line summary

> Issue : #1234 (only if appropriate)

## Description

Replaces `EnableOnly` / `DisableOnly` by `DiffingOption` to be sure only one is set.

## Types of Changes

- New feature (non-breaking change which adds functionality)
- Refactor/improvements
- Breaking-change