### PR TITLE
[Python] WebElement Support (Robot & No Framework)

### DIFF
--- a/visual-python/integration-tests/robot/integration/__init__.robot
+++ b/visual-python/integration-tests/robot/integration/__init__.robot
@@ -1,0 +1,11 @@
+*** Settings ***
+Resource    resource.robot
+Suite Setup    Setup
+Suite Teardown    Close Browser
+
+
+*** Keywords ***
+Setup
+    Setup Suite
+    Open Desktop Browser
+    Run Test

--- a/visual-python/integration-tests/robot/integration/clipping.robot
+++ b/visual-python/integration-tests/robot/integration/clipping.robot
@@ -1,0 +1,13 @@
+*** Settings ***
+Documentation     A test suite with test for various clipping utilities.
+Resource          resource.robot
+Test Timeout    5 minutes
+
+*** Test Cases ***
+Clipping
+    Visual Snapshot    Clip Selector    clip_selector=.inventory_list
+    # Should fail if the requested element is not found
+    Run Keyword And Expect Error    STARTS:TransportQueryError    Visual Snapshot    Clip Selector    clip_selector=.no-element-found
+
+    ${element} =    Get Webelement    class:inventory_list
+    Visual Snapshot    Clip Element    clip_element=${element}

--- a/visual-python/integration-tests/robot/integration/full_page_screenshot.robot
+++ b/visual-python/integration-tests/robot/integration/full_page_screenshot.robot
@@ -1,0 +1,12 @@
+*** Settings ***
+Documentation     A test suite with test for various clipping utilities.
+Resource          resource.robot
+Test Timeout    5 minutes
+
+*** Test Cases ***
+Full Page Screenshot
+    Visual Snapshot    Bool    full_page_config=True
+    Visual Snapshot    Scroll Limit    full_page_config={"scroll_limit": 1}
+    Visual Snapshot    Enable Scroll Bars    full_page_config={"hide_scroll_bars": False}
+    ${config} =     Visual FullPageConfig    scroll_limit=1
+    Visual Snapshot    Config Object    full_page_config=${config}

--- a/visual-python/integration-tests/robot/integration/ignore_regions.robot
+++ b/visual-python/integration-tests/robot/integration/ignore_regions.robot
@@ -4,33 +4,16 @@ Documentation     A test suite with a single test for valid login.
 ...               This test has a workflow that is created using keywords in
 ...               the imported resource file.
 Resource          resource.robot
-Suite Setup    Setup Suite
 Test Timeout    5 minutes
 
-
-*** Keywords ***
-Cropping FPS Suite
-    Run Test
+*** Test Cases ***
+Cropping
     Visual Snapshot    Standard    ignore_regions=["class:inventory_item_img", "class:btn_inventory"]    capture_dom=True
     Visual Snapshot    Clipped    ignore_regions=["class:inventory_item_img", "class:btn_inventory"]    clip_selector=.inventory_list    capture_dom=True
     Visual Snapshot    FPS    ignore_regions=["class:inventory_item_img", "class:btn_inventory"]    full_page_config=True    capture_dom=True
     Visual Snapshot    Clipped (FPS)    ignore_regions=["class:inventory_item_img", "class:btn_inventory"]    clip_selector=.inventory_list     full_page_config=True    capture_dom=True
 
-*** Test Cases ***
-Desktop Cropping
-    Open Desktop Browser
-    Cropping FPS Suite
-    Close Browser
-
-Mobile Cropping
-    Open Mobile Browser
-    Cropping FPS Suite
-    Close Browser
-
 Ignore Region Parsing
-    Open Desktop Browser
-    Run Test
-    
     # An array of web elements in ignore region
     ${elements}    Get Webelements    class:inventory_item_img
     ${inventory_images} =     Visual Ignore Element    ${elements}    diffing_options={"style": True}
@@ -50,5 +33,4 @@ Ignore Region Parsing
     
     Visual Snapshot    Ignore Regions List    capture_dom=True    ignore_regions=${ignore_regions}    full_page_config=True    diffing_method=BALANCED
     Visual Snapshot    Inline Dict    capture_dom=True    ignore_regions=[{"x": 200, "y": 200, "width": 200, "height": 200}]    full_page_config=True    diffing_method=BALANCED
-    
-    Close Browser
+

--- a/visual-python/requirements/user.txt
+++ b/visual-python/requirements/user.txt
@@ -3,3 +3,4 @@ gql==3.5.0
 requests>=2.1.0
 requests-toolbelt>=1.0.0
 tabulate>=0.9.0
+selenium>=4.0.0

--- a/visual-python/src/saucelabs_visual/client.py
+++ b/visual-python/src/saucelabs_visual/client.py
@@ -172,7 +172,6 @@ class SauceLabsVisual:
             suite_name: Union[str, None] = None,
             capture_dom: bool = False,
             clip_selector: Union[str, None] = None,
-            clip_element: Union[WebElement, None] = None,
             ignore_regions: Union[List[IgnoreRegion], None] = None,
             ignore_elements: Union[List[IgnoreElementRegion], None] = None,
             full_page_config: Union[FullPageConfig, None] = None,
@@ -187,7 +186,6 @@ class SauceLabsVisual:
         :param suite_name: The name of the current test to group / identify in the UI.
         :param capture_dom: Whether we should capture the DOM while taking a screenshot.
         :param clip_selector: A CSS selector that we should clip the screenshot to.
-        :param clip_element: A WebElement instance we should clip the screenshot to.
         :param ignore_regions: One or more regions on the page that we should ignore changes in.
         :param ignore_elements: One or more `IgnoreElementRegion`s we should ignore.
         :param full_page_config: Enable or adjust the behavior of Visual full page screenshots.
@@ -208,9 +206,7 @@ class SauceLabsVisual:
                 $suiteName: String,
                 $captureDom: Boolean,
                 $clipSelector: String,
-                $clipElement: WebdriverElementID,
                 $ignoreRegions: [RegionIn!],
-                $ignoreElements: [ElementIn!],
                 $fullPageConfig: FullPageConfigIn,
                 $diffingMethod: DiffingMethod,
                 $diffingOptions: DiffingOptionsIn,
@@ -224,9 +220,7 @@ class SauceLabsVisual:
                     suiteName: $suiteName,
                     captureDom: $captureDom,
                     clipSelector: $clipSelector,
-                    clipElement: $clipElement,
                     ignoreRegions: $ignoreRegions,
-                    ignoreElements: $ignoreElements,
                     fullPageConfig: $fullPageConfig,
                     diffingMethod: $diffingMethod,
                     diffingOptions: $diffingOptions,
@@ -246,15 +240,9 @@ class SauceLabsVisual:
             "suiteName": suite_name,
             "captureDom": capture_dom,
             "clipSelector": clip_selector,
-            "clipElement": clip_element.id if clip_element is not None else None,
             "ignoreRegions": [
                 region.asdict() for region in ignore_regions
             ] if ignore_regions is not None else None,
-            "ignoreElements": [
-                element
-                for group in ignore_elements
-                for element in group.asdictarray()
-            ] if ignore_elements is not None else None,
             "fullPageConfig": full_page_config,
             "diffingMethod": (diffing_method or DiffingMethod.SIMPLE).value,
             "diffingOptions": diffing_options,

--- a/visual-python/src/saucelabs_visual/client.py
+++ b/visual-python/src/saucelabs_visual/client.py
@@ -7,10 +7,11 @@ from typing import List, Union
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 from requests.auth import HTTPBasicAuth
+from selenium.webdriver.remote.webelement import WebElement
 
 from saucelabs_visual.regions import Region
 from saucelabs_visual.typing import IgnoreRegion, FullPageConfig, DiffingMethod, BuildStatus, \
-    DiffingOptions
+    DiffingOptions, IgnoreElementRegion
 
 PKG_VERSION = '0.0.11'
 
@@ -171,7 +172,9 @@ class SauceLabsVisual:
             suite_name: Union[str, None] = None,
             capture_dom: bool = False,
             clip_selector: Union[str, None] = None,
+            clip_element: Union[WebElement, None] = None,
             ignore_regions: Union[List[IgnoreRegion], None] = None,
+            ignore_elements: Union[List[IgnoreElementRegion], None] = None,
             full_page_config: Union[FullPageConfig, None] = None,
             diffing_method: DiffingMethod = DiffingMethod.SIMPLE,
             diffing_options: Union[DiffingOptions, None] = None,
@@ -184,7 +187,9 @@ class SauceLabsVisual:
         :param suite_name: The name of the current test to group / identify in the UI.
         :param capture_dom: Whether we should capture the DOM while taking a screenshot.
         :param clip_selector: A CSS selector that we should clip the screenshot to.
+        :param clip_element: A WebElement instance we should clip the screenshot to.
         :param ignore_regions: One or more regions on the page that we should ignore changes in.
+        :param ignore_elements: One or more `IgnoreElementRegion`s we should ignore.
         :param full_page_config: Enable or adjust the behavior of Visual full page screenshots.
         :param diffing_method: The diffing method we should use for comparison.
         :param diffing_options: Options to customize the DOM <-> Visual behavior for the BALANCED
@@ -203,7 +208,9 @@ class SauceLabsVisual:
                 $suiteName: String,
                 $captureDom: Boolean,
                 $clipSelector: String,
+                $clipElement: WebdriverElementID,
                 $ignoreRegions: [RegionIn!],
+                $ignoreElements: [ElementIn!],
                 $fullPageConfig: FullPageConfigIn,
                 $diffingMethod: DiffingMethod,
                 $diffingOptions: DiffingOptionsIn,
@@ -217,7 +224,9 @@ class SauceLabsVisual:
                     suiteName: $suiteName,
                     captureDom: $captureDom,
                     clipSelector: $clipSelector,
+                    clipElement: $clipElement,
                     ignoreRegions: $ignoreRegions,
+                    ignoreElements: $ignoreElements,
                     fullPageConfig: $fullPageConfig,
                     diffingMethod: $diffingMethod,
                     diffingOptions: $diffingOptions,
@@ -237,9 +246,15 @@ class SauceLabsVisual:
             "suiteName": suite_name,
             "captureDom": capture_dom,
             "clipSelector": clip_selector,
+            "clipElement": clip_element.id if clip_element is not None else None,
             "ignoreRegions": [
-                asdict(region) for region in ignore_regions
+                region.asdict() for region in ignore_regions
             ] if ignore_regions is not None else None,
+            "ignoreElements": [
+                element
+                for group in ignore_elements
+                for element in group.asdictarray()
+            ] if ignore_elements is not None else None,
             "fullPageConfig": full_page_config,
             "diffingMethod": (diffing_method or DiffingMethod.SIMPLE).value,
             "diffingOptions": diffing_options,

--- a/visual-python/src/saucelabs_visual/client.py
+++ b/visual-python/src/saucelabs_visual/client.py
@@ -12,7 +12,6 @@ from selenium.webdriver.remote.webelement import WebElement
 from saucelabs_visual.regions import Region
 from saucelabs_visual.typing import IgnoreRegion, FullPageConfig, DiffingMethod, BuildStatus, \
     DiffingOptions, IgnoreElementRegion
-from saucelabs_visual.utils import ignore_region_from_dict
 
 PKG_VERSION = '0.0.11'
 
@@ -165,47 +164,6 @@ class SauceLabsVisual:
 
         return meta
 
-    def _merge_ignore_regions(
-            self,
-            ignore_regions: Union[List[IgnoreRegion], None],
-            ignore_elements: Union[List[IgnoreElementRegion], None],
-    ):
-        def as_region_array(region: IgnoreElementRegion):
-            """
-            Returns the ignore element region as a series of IgnoreRegions instead of element based
-            regions until full backend element support is available.
-            :return:
-            """
-            element_array = region.element if isinstance(region.element, List) else [region.element]
-
-            return [
-                ignore_region_from_dict(
-                    element.rect,
-                    name=region.name,
-                    diffing_options=region.diffingOptions
-                )
-                for element in element_array
-            ]
-
-        ignore_regions = ignore_regions if ignore_regions is not None else ignore_regions
-        ignore_elements = ignore_elements if ignore_elements is not None else ignore_elements
-
-        # Parse element-based ignore regions and merge them into the coordinate based ones until
-        # backend element support is available.
-        ignore_regions_merged: List[IgnoreRegion] = []
-        ignore_regions_merged.extend(
-            [
-                region.as_dict() for region in ignore_regions
-            ] if ignore_regions is not None else []
-        )
-        ignore_regions_merged.extend(
-            element.as_dict()
-            for group in ignore_elements
-            for element in as_region_array(group)
-        )
-
-        return ignore_regions_merged
-
     def create_snapshot_from_webdriver(
             self,
             name: str,
@@ -214,6 +172,7 @@ class SauceLabsVisual:
             suite_name: Union[str, None] = None,
             capture_dom: bool = False,
             clip_selector: Union[str, None] = None,
+            clip_element: Union[WebElement, None] = None,
             ignore_regions: Union[List[IgnoreRegion], None] = None,
             ignore_elements: Union[List[IgnoreElementRegion], None] = None,
             full_page_config: Union[FullPageConfig, None] = None,
@@ -228,6 +187,7 @@ class SauceLabsVisual:
         :param suite_name: The name of the current test to group / identify in the UI.
         :param capture_dom: Whether we should capture the DOM while taking a screenshot.
         :param clip_selector: A CSS selector that we should clip the screenshot to.
+        :param clip_element: A WebElement instance we should clip the screenshot to.
         :param ignore_regions: One or more regions on the page that we should ignore changes in.
         :param ignore_elements: One or more `IgnoreElementRegion`s we should ignore.
         :param full_page_config: Enable or adjust the behavior of Visual full page screenshots.
@@ -248,7 +208,9 @@ class SauceLabsVisual:
                 $suiteName: String,
                 $captureDom: Boolean,
                 $clipSelector: String,
+                $clipElement: WebdriverElementID,
                 $ignoreRegions: [RegionIn!],
+                $ignoreElements: [ElementIn!],
                 $fullPageConfig: FullPageConfigIn,
                 $diffingMethod: DiffingMethod,
                 $diffingOptions: DiffingOptionsIn,
@@ -262,7 +224,9 @@ class SauceLabsVisual:
                     suiteName: $suiteName,
                     captureDom: $captureDom,
                     clipSelector: $clipSelector,
+                    clipElement: $clipElement,
                     ignoreRegions: $ignoreRegions,
+                    ignoreElements: $ignoreElements,
                     fullPageConfig: $fullPageConfig,
                     diffingMethod: $diffingMethod,
                     diffingOptions: $diffingOptions,
@@ -273,7 +237,6 @@ class SauceLabsVisual:
             """
         )
         meta = self._get_meta(session_id)
-        ignore_regions_merged = self._merge_ignore_regions(ignore_regions, ignore_elements)
         values = {
             "name": name,
             "sessionId": session_id,
@@ -283,8 +246,16 @@ class SauceLabsVisual:
             "suiteName": suite_name,
             "captureDom": capture_dom,
             "clipSelector": clip_selector,
-            "ignoreRegions": ignore_regions_merged,
-            "fullPageConfig": full_page_config,
+            "clipElement": clip_element.id if clip_element is not None else None,
+            "ignoreRegions": [
+                asdict(region) for region in ignore_regions
+            ] if ignore_regions is not None else None,
+            "ignoreElements": [
+                element
+                for group in ignore_elements
+                for element in group.as_dict_array()
+            ] if ignore_elements is not None else None,
+            "fullPageConfig": asdict(full_page_config) if full_page_config is not None else None,
             "diffingMethod": (diffing_method or DiffingMethod.SIMPLE).value,
             "diffingOptions": diffing_options,
         }

--- a/visual-python/src/saucelabs_visual/frameworks/robot.py
+++ b/visual-python/src/saucelabs_visual/frameworks/robot.py
@@ -70,14 +70,9 @@ class SauceLabsVisual:
         elif literal_type is bool:
             parsed_value = {} if literal is True else None
 
-        hide_elements_after_first_scroll = [
-            element.id for element in (parsed_value.get('hide_elements_after_first_scroll') or [])
-        ]
-
         return FullPageConfig(
             delayAfterScrollMs=parsed_value.get('delay_after_scroll_ms'),
             hideAfterFirstScroll=parsed_value.get('hide_after_first_scroll'),
-            hideElementsAfterFirstScroll=hide_elements_after_first_scroll,
             disableCSSAnimation=parsed_value.get('disable_css_animation'),
             hideScrollBars=parsed_value.get('hide_scroll_bars'),
             scrollLimit=parsed_value.get('scroll_limit'),

--- a/visual-python/src/saucelabs_visual/frameworks/robot.py
+++ b/visual-python/src/saucelabs_visual/frameworks/robot.py
@@ -226,7 +226,6 @@ class SauceLabsVisual:
             name: str,
             capture_dom: bool = False,
             clip_selector: Union[str, None] = None,
-            clip_element: Union[WebElement, None] = None,
             ignore_regions: List[Union[
                 List[WebElement], IgnoreRegion, str, WebElement, IgnoreElementRegion, dict
             ]] = None,
@@ -253,7 +252,6 @@ class SauceLabsVisual:
             suite_name=BuiltIn().get_variable_value('\${SUITE NAME}'),
             capture_dom=capture_dom,
             clip_selector=clip_selector,
-            clip_element=clip_element,
             ignore_regions=parsed_ignore_regions,
             ignore_elements=parsed_ignore_elements,
             full_page_config=parsed_fpc,

--- a/visual-python/src/saucelabs_visual/typing.py
+++ b/visual-python/src/saucelabs_visual/typing.py
@@ -62,8 +62,9 @@ class IgnoreRegion(IgnoreBase):
     diffingOptions: Union[DiffingOptions, None] = None
     name: Union[str, None] = None
 
-    def asdict(self):
+    def as_dict(self):
         return asdict(self)
+
 
 @dataclass
 class IgnoreElementRegion(IgnoreBase):
@@ -71,7 +72,7 @@ class IgnoreElementRegion(IgnoreBase):
     diffingOptions: Union[DiffingOptions, None] = None
     name: Union[str, None] = None
 
-    def asdictarray(self):
+    def as_dict_array(self):
         element_array = self.element if isinstance(self.element, List) else [self.element]
         return [
             {

--- a/visual-python/src/saucelabs_visual/typing.py
+++ b/visual-python/src/saucelabs_visual/typing.py
@@ -62,9 +62,6 @@ class IgnoreRegion(IgnoreBase):
     diffingOptions: Union[DiffingOptions, None] = None
     name: Union[str, None] = None
 
-    def as_dict(self):
-        return asdict(self)
-
 
 @dataclass
 class IgnoreElementRegion(IgnoreBase):
@@ -83,25 +80,26 @@ class IgnoreElementRegion(IgnoreBase):
         ]
 
 
-class FullPageConfig(TypedDict):
-    delayAfterScrollMs: NotRequired[int]
+@dataclass
+class FullPageConfig:
+    delayAfterScrollMs: Union[int, None] = None
     """
     Delay in ms after scrolling and before taking screenshots. A slight delay can be helpful for
     websites leveraging lazy loading.
     """
-    hideAfterFirstScroll: NotRequired[List[str]]
+    hideAfterFirstScroll: Union[List[str], None] = None
     """
     A list of CSS selectors for elements to hide after the first scroll.
     """
-    disableCSSAnimation: NotRequired[bool]
+    disableCSSAnimation: Union[bool, None] = None
     """
     Disable CSS animations and the input caret for the site under test.
     """
-    hideScrollBars: NotRequired[bool]
+    hideScrollBars: Union[bool, None] = None
     """
     Hide all scrollbars for the site under test.
     """
-    scrollLimit: NotRequired[int]
+    scrollLimit: Union[int, None] = None
     """
     Limit the number of screenshots taken for scrolling and stitching. Default and max value is 10.
     """

--- a/visual-python/src/saucelabs_visual/typing.py
+++ b/visual-python/src/saucelabs_visual/typing.py
@@ -93,10 +93,6 @@ class FullPageConfig(TypedDict):
     """
     A list of CSS selectors for elements to hide after the first scroll.
     """
-    hideElementsAfterFirstScroll: NotRequired[List[str]]
-    """
-    A list of WebElements to hide after the first scroll.
-    """
     disableCSSAnimation: NotRequired[bool]
     """
     Disable CSS animations and the input caret for the site under test.

--- a/visual-python/src/saucelabs_visual/typing.py
+++ b/visual-python/src/saucelabs_visual/typing.py
@@ -1,7 +1,8 @@
-from dataclasses import dataclass, InitVar
+from dataclasses import dataclass, InitVar, asdict
 from enum import Enum
 from typing import List, Union, Literal
 
+from selenium.webdriver.remote.webelement import WebElement
 from typing_extensions import TypedDict, NotRequired
 
 
@@ -61,6 +62,25 @@ class IgnoreRegion(IgnoreBase):
     diffingOptions: Union[DiffingOptions, None] = None
     name: Union[str, None] = None
 
+    def asdict(self):
+        return asdict(self)
+
+@dataclass
+class IgnoreElementRegion(IgnoreBase):
+    element: Union[WebElement, List[WebElement]]
+    diffingOptions: Union[DiffingOptions, None] = None
+    name: Union[str, None] = None
+
+    def asdictarray(self):
+        element_array = self.element if isinstance(self.element, List) else [self.element]
+        return [
+            {
+                "id": element.id,
+                "diffingOptions": self.diffingOptions,
+                "name": self.name,
+            } for element in element_array
+        ]
+
 
 class FullPageConfig(TypedDict):
     delayAfterScrollMs: NotRequired[int]
@@ -70,7 +90,11 @@ class FullPageConfig(TypedDict):
     """
     hideAfterFirstScroll: NotRequired[List[str]]
     """
-    Adjust address bar padding on iOS and Android for viewport cutout.
+    A list of CSS selectors for elements to hide after the first scroll.
+    """
+    hideElementsAfterFirstScroll: NotRequired[List[str]]
+    """
+    A list of WebElements to hide after the first scroll.
     """
     disableCSSAnimation: NotRequired[bool]
     """

--- a/visual-python/src/saucelabs_visual/utils.py
+++ b/visual-python/src/saucelabs_visual/utils.py
@@ -1,5 +1,6 @@
-from saucelabs_visual.typing import IgnoreRegion, BuildMode, BuildStatus, DiffingOptions
 from tabulate import tabulate
+
+from saucelabs_visual.typing import IgnoreRegion, BuildMode, BuildStatus, DiffingOptions
 
 
 def ignore_region_from_dict(


### PR DESCRIPTION
## Description

Adds WebElement support to both Robot Framework and the standard library. Allows passing IgnoreElementRegions with a `WebElement` or `WebElement[]` in the `element` field. 

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
- Refactor/improvements

