### PR TITLE
Let backend handle device pixel ratio in cypress

### DIFF
--- a/visual-js/.changeset/soft-shirts-destroy.md
+++ b/visual-js/.changeset/soft-shirts-destroy.md
@@ -1,0 +1,5 @@
+---
+"@saucelabs/cypress-visual-plugin": patch
+---
+
+Let backend handle device pixel ratio in cypress

--- a/visual-js/visual-cypress/src/commands.ts
+++ b/visual-js/visual-cypress/src/commands.ts
@@ -168,13 +168,10 @@ const sauceVisualCheckCommand = (
           hasError = true;
         }
 
-        const applyScalingRatio = !isRegion(visualRegions[idx].element);
-
         for (const plainRegion of regions[idx]) {
           result.push({
             ...visualRegions[idx],
             element: plainRegion,
-            applyScalingRatio,
           } satisfies ResolvedVisualRegion);
         }
       }

--- a/visual-js/visual-cypress/src/types.ts
+++ b/visual-js/visual-cypress/src/types.ts
@@ -36,9 +36,7 @@ export type VisualRegion<
   R extends Omit<object, 'element'> = PlainRegion | Cypress.Chainable,
 > = { element: R } & SelectiveRegionOptions;
 
-export type ResolvedVisualRegion = {
-  applyScalingRatio?: boolean;
-} & VisualRegion<PlainRegion>;
+export type ResolvedVisualRegion = VisualRegion<PlainRegion>;
 
 export type ScreenshotMetadata = {
   id: string;

--- a/visual-js/visual-cypress/src/types.ts
+++ b/visual-js/visual-cypress/src/types.ts
@@ -45,7 +45,7 @@ export type ScreenshotMetadata = {
   name: string;
   testName: string;
   suiteName: string;
-  regions?: ResolvedVisualRegion[];
+  regions: ResolvedVisualRegion[];
   diffingMethod?: DiffingMethod;
   diffingOptions?: DiffingOptionsIn;
   viewport: SauceVisualViewport | undefined;


### PR DESCRIPTION
Fixes DPR computation in cypress. All (ignore) region coordinates are expected in DOM pixels without DPR applied. DPR is applied by the backend now.

> Issue : IRIS-997

