### PR TITLE
Allow to define region via env variables.

### DIFF
--- a/visual-dotnet/SauceLabs.Visual/Region.cs
+++ b/visual-dotnet/SauceLabs.Visual/Region.cs
@@ -31,12 +31,13 @@ namespace SauceLabs.Visual
 
         /// <summary>
         /// <c>FromEnvironment</c> returns the <c>Region</c> instance based on the environment SAUCE_REGION.
+        /// If the env variable is unavailable, the default region will be returned - 
         /// </summary>
         /// <returns>the matching <c>Region</c> instance</returns>
         /// <exception cref="VisualClientException"></exception>
         public static Region FromEnvironment()
         {
-            return FromName(EnvVars.Region);
+            return string.IsNullOrEmpty(EnvVars.Region) ? FromName(EnvVars.Region) : UsWest1;
         }
 
         /// <summary>

--- a/visual-dotnet/SauceLabs.Visual/Region.cs
+++ b/visual-dotnet/SauceLabs.Visual/Region.cs
@@ -29,6 +29,11 @@ namespace SauceLabs.Visual
             return Value.ToString();
         }
 
+        /// <summary>
+        /// <c>FromEnvironment</c> returns the <c>Region</c> instance based on the environment SAUCE_REGION.
+        /// </summary>
+        /// <returns>the matching <c>Region</c> instance</returns>
+        /// <exception cref="VisualClientException"></exception>
         public static Region FromEnvironment()
         {
             return FromName(EnvVars.Region);

--- a/visual-dotnet/SauceLabs.Visual/Region.cs
+++ b/visual-dotnet/SauceLabs.Visual/Region.cs
@@ -1,3 +1,4 @@
+using SauceLabs.Visual.Utils;
 using System;
 
 namespace SauceLabs.Visual
@@ -26,6 +27,11 @@ namespace SauceLabs.Visual
         public override string ToString()
         {
             return Value.ToString();
+        }
+
+        public static Region FromEnvironment()
+        {
+            return FromName(EnvVars.Region);
         }
 
         /// <summary>

--- a/visual-dotnet/SauceLabs.Visual/Utils/EnvVars.cs
+++ b/visual-dotnet/SauceLabs.Visual/Utils/EnvVars.cs
@@ -15,5 +15,6 @@ namespace SauceLabs.Visual.Utils
         internal static string BuildId => Environment.GetEnvironmentVariable("SAUCE_VISUAL_BUILD_ID") ?? "";
         internal static string Username => Environment.GetEnvironmentVariable("SAUCE_USERNAME") ?? "";
         internal static string AccessKey => Environment.GetEnvironmentVariable("SAUCE_ACCESS_KEY") ?? "";
+        internal static string Region => Environment.GetEnvironmentVariable("SAUCE_REGION") ?? "";
     }
 }

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -41,6 +41,7 @@ namespace SauceLabs.Visual
         /// Creates a new instance of <c>VisualClient</c>
         /// </summary>
         /// <param name="wd">the instance of the WebDriver session</param>
+        /// <param name="buildOptions">the options of the build creation</param>
         public static async Task<VisualClient> Create(WebDriver wd, CreateBuildOptions buildOptions)
         {
             return await Create(wd, Region.FromEnvironment(), EnvVars.Username, EnvVars.AccessKey, buildOptions);

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -32,6 +32,24 @@ namespace SauceLabs.Visual
         /// Creates a new instance of <c>VisualClient</c>
         /// </summary>
         /// <param name="wd">the instance of the WebDriver session</param>
+        public static async Task<VisualClient> Create(WebDriver wd)
+        {
+            return await Create(wd, Region.FromEnvironment(), EnvVars.Username, EnvVars.AccessKey, new CreateBuildOptions());
+        }
+
+        /// <summary>
+        /// Creates a new instance of <c>VisualClient</c>
+        /// </summary>
+        /// <param name="wd">the instance of the WebDriver session</param>
+        public static async Task<VisualClient> Create(WebDriver wd, CreateBuildOptions buildOptions)
+        {
+            return await Create(wd, Region.FromEnvironment(), EnvVars.Username, EnvVars.AccessKey, buildOptions);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <c>VisualClient</c>
+        /// </summary>
+        /// <param name="wd">the instance of the WebDriver session</param>
         /// <param name="region">the Sauce Labs region to connect to</param>
         public static async Task<VisualClient> Create(WebDriver wd, Region region)
         {


### PR DESCRIPTION
# One-line summary
This pull request adds region support to C# SDK.

## Description
Since we have support for username, and password, we don't need to require sauce region if it is already there. Most of the time our examples require sauce region to be available. Our users also most likely have them 

## Types of Changes
New feature (non-breaking change which adds functionality)

## Tasks
[x] support ignore regions via env variables

## Review
_List of tasks the reviewer must do to review the PR_
- [x] Tests
- [x] Documentation
- [x] CHANGELOG

## Deployment Notes
-
