### PR TITLE
Use ossrh username and token for java publishing

### DIFF
--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -57,8 +57,8 @@ jobs:
           mvn -P release -Dgpg.passphrase="${{ secrets.MVN_CENTRAL_GPG_PASSPHRASE }}" \
               -Drevision=${{ steps.upgrade.outputs.version }} deploy
         env:
-          MVN_CENTRAL_USERNAME: ${{ secrets.MVN_CENTRAL_USERNAME }}
-          MVN_CENTRAL_PASSWORD: ${{ secrets.MVN_CENTRAL_PASSWORD }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
 
       - name: Push new version to Git
         id: push_to_git

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -28,8 +28,8 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
           server-id: ossrh
-          server-username: MVN_CENTRAL_USERNAME
-          server-password: MVN_CENTRAL_PASSWORD
+          server-username: OSSRH_USERNAME
+          server-password: OSSRH_TOKEN
 
       - name: Setup Git
         if: ${{ steps.prep.outputs.tag_name == '' }}


### PR DESCRIPTION
https://central.sonatype.org/news/20240617_migration_of_accounts/#publishing-with-username-password
New creds should fix this