### PR TITLE
[C#] Add baselineOverride functionality

### DIFF
--- a/visual-dotnet/SauceLabs.Visual/BaselineOverride.cs
+++ b/visual-dotnet/SauceLabs.Visual/BaselineOverride.cs
@@ -3,6 +3,11 @@ using SauceLabs.Visual.Models;
 
 namespace SauceLabs.Visual
 {
+    /// <summary>
+    /// <c>BaselineOverride</c> One or more values from 'SnapshotIn' we should use as an override
+    /// when finding a baseline. Enables cross browser / OS snapshot comparison by matching the
+    /// values set on the device you'd like to compare against.
+    /// </summary>
     public class BaselineOverride
     {
         public Browser? Browser { get; set; }

--- a/visual-dotnet/SauceLabs.Visual/BaselineOverride.cs
+++ b/visual-dotnet/SauceLabs.Visual/BaselineOverride.cs
@@ -1,0 +1,32 @@
+using SauceLabs.Visual.GraphQL;
+using SauceLabs.Visual.Models;
+
+namespace SauceLabs.Visual
+{
+    public class BaselineOverride
+    {
+        public Browser? Browser { get; set; }
+        public string? BrowserVersion { get; set; }
+        public string? Device { get; set; }
+        public string? Name { get; set; }
+        public OperatingSystem? OperatingSystem { get; set; }
+        public string? OperatingSystemVersion { get; set; }
+        public string? SuiteName { get; set; }
+        public string? TestName { get; set; }
+
+        internal BaselineOverrideIn ToBaselineOverrideIn()
+        {
+            return new BaselineOverrideIn()
+            {
+                Browser = Browser,
+                BrowserVersion = BrowserVersion,
+                Device = Device,
+                Name = Name,
+                OperatingSystem = OperatingSystem,
+                OperatingSystemVersion = OperatingSystemVersion,
+                SuiteName = SuiteName,
+                TestName = TestName,
+            };
+        }
+    }
+}

--- a/visual-dotnet/SauceLabs.Visual/CreateBuildOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/CreateBuildOptions.cs
@@ -1,6 +1,3 @@
-using OpenQA.Selenium;
-using SauceLabs.Visual.Models;
-
 namespace SauceLabs.Visual
 {
 

--- a/visual-dotnet/SauceLabs.Visual/GraphQL/BaselineOverrideIn.cs
+++ b/visual-dotnet/SauceLabs.Visual/GraphQL/BaselineOverrideIn.cs
@@ -1,0 +1,25 @@
+using Newtonsoft.Json;
+using SauceLabs.Visual.Models;
+
+namespace SauceLabs.Visual.GraphQL
+{
+    internal class BaselineOverrideIn
+    {
+        [JsonProperty("browser", NullValueHandling = NullValueHandling.Ignore)]
+        public Browser? Browser { get; set; }
+        [JsonProperty("browserVersion", NullValueHandling = NullValueHandling.Ignore)]
+        public string? BrowserVersion { get; set; }
+        [JsonProperty("device", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Device { get; set; }
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+        public string? Name { get; set; }
+        [JsonProperty("operatingSystem", NullValueHandling = NullValueHandling.Ignore)]
+        public OperatingSystem? OperatingSystem { get; set; }
+        [JsonProperty("operatingSystemVersion", NullValueHandling = NullValueHandling.Ignore)]
+        public string? OperatingSystemVersion { get; set; }
+        [JsonProperty("suiteName", NullValueHandling = NullValueHandling.Ignore)]
+        public string? SuiteName { get; set; }
+        [JsonProperty("testName", NullValueHandling = NullValueHandling.Ignore)]
+        public string? TestName { get; set; }
+    }
+}

--- a/visual-dotnet/SauceLabs.Visual/GraphQL/CreateSnapshotFromWebDriverIn.cs
+++ b/visual-dotnet/SauceLabs.Visual/GraphQL/CreateSnapshotFromWebDriverIn.cs
@@ -29,7 +29,8 @@ namespace SauceLabs.Visual.GraphQL
         public string? TestName { get; set; }
         [JsonProperty("captureDom")]
         public bool? CaptureDom { get; set; }
-
+        [JsonProperty("baselineOverride")]
+        public BaselineOverrideIn? BaselineOverride { get; set; }
         [JsonProperty("clipSelector")]
         public string? ClipSelector { get; set; }
         [JsonProperty("clipElement")]
@@ -52,7 +53,8 @@ namespace SauceLabs.Visual.GraphQL
             string? testName,
             ElementIn[]? ignoredElements,
             FullPageConfigIn? fullPageConfig,
-            DiffingOptionsIn? diffingOptions
+            DiffingOptionsIn? diffingOptions,
+            BaselineOverrideIn? baselineOverride
         )
         {
             BuildUuid = buildUuid;
@@ -70,6 +72,7 @@ namespace SauceLabs.Visual.GraphQL
             TestName = testName;
             FullPageConfig = fullPageConfig;
             DiffingOptions = diffingOptions;
+            BaselineOverride = baselineOverride;
         }
     }
 }

--- a/visual-dotnet/SauceLabs.Visual/Models/Browser.cs
+++ b/visual-dotnet/SauceLabs.Visual/Models/Browser.cs
@@ -1,0 +1,11 @@
+namespace SauceLabs.Visual.Models
+{
+    public enum Browser
+    {
+        Chrome,
+        Edge,
+        Firefox,
+        PlaywrightWebkit,
+        Safari,
+    }
+}

--- a/visual-dotnet/SauceLabs.Visual/Models/OperatingSystem.cs
+++ b/visual-dotnet/SauceLabs.Visual/Models/OperatingSystem.cs
@@ -1,0 +1,11 @@
+namespace SauceLabs.Visual.Models
+{
+    public enum OperatingSystem
+    {
+        Android,
+        Ios,
+        Linux,
+        Macos,
+        Windows,
+    }
+}

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
@@ -38,7 +38,7 @@ namespace SauceLabs.Visual
         /// <c>TestName</c> manually set the TestName of the Test.
         /// </summary>
         public string? TestName { get; set; }
-        
+
         /// <summary>
         /// <c>BaselineOverride</c> override the baseline matching behavior for the test.
         /// </summary>

--- a/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualCheckOptions.cs
@@ -38,6 +38,11 @@ namespace SauceLabs.Visual
         /// <c>TestName</c> manually set the TestName of the Test.
         /// </summary>
         public string? TestName { get; set; }
+        
+        /// <summary>
+        /// <c>BaselineOverride</c> override the baseline matching behavior for the test.
+        /// </summary>
+        public BaselineOverride? BaselineOverride { get; set; }
 
         private bool HasCompleteTestContext()
         {

--- a/visual-dotnet/SauceLabs.Visual/VisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClient.cs
@@ -24,6 +24,7 @@ namespace SauceLabs.Visual
         private readonly List<string> _screenshotIds = new List<string>();
         public VisualBuild Build { get; private set; }
         public bool CaptureDom { get; set; } = false;
+        public BaselineOverride? BaselineOverride { get; set; }
         private readonly ResiliencePipeline _retryPipeline;
 
         private string? _previousSuiteName = null;
@@ -183,7 +184,8 @@ namespace SauceLabs.Visual
                 suiteName: options.SuiteName,
                 testName: options.TestName,
                 fullPageConfig: fullPageConfigIn,
-                diffingOptions: options.DiffingOptions?.ToDiffingOptionsIn()
+                diffingOptions: options.DiffingOptions?.ToDiffingOptionsIn(),
+                baselineOverride: (options.BaselineOverride ?? BaselineOverride)?.ToBaselineOverrideIn()
             ))).EnsureValidResponse();
             result.Result.Diffs.Nodes.ToList().ForEach(d => _screenshotIds.Add(d.Id));
             return result.Result.Id;


### PR DESCRIPTION
## Description
Adds the ability to override the baseline matching behavior at a build or visual check level.

## Types of Changes
- New feature (non-breaking change which adds functionality)
