### PR TITLE
[Python] Baseline Overrides / Mobile support

### DIFF
--- a/visual-python/Dockerfile
+++ b/visual-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.11-slim-bookworm
 
 COPY . .
 

--- a/visual-python/integration-tests/robot/integration/cross_browser.robot
+++ b/visual-python/integration-tests/robot/integration/cross_browser.robot
@@ -1,0 +1,24 @@
+*** Settings ***
+Resource          resource.robot
+Test Timeout    5 minutes
+
+*** Test Cases ***
+Baseline
+    
+    Visual Set Global DiffingMethod    BALANCED
+    Visual Set Global CaptureDom    True
+    ${override} =    Visual BaselineOverride    device=Desktop (1920x900)    browser=CHROME    browser_version=127.0
+    Visual Set Global BaselineOverride    ${override}
+    ${full_page_config} =    Visual FullPageConfig
+    Visual Set Global FullPageConfig    ${full_page_config}
+    Visual Snapshot     Inventory Page
+
+    ${override} =    Visual BaselineOverride    device=Desktop (1920x900)    browser=CHROME    browser_version=127.0
+    ${fpc} =     Visual FullPageConfig    scroll_limit=1
+    Visual Snapshot    Inventory Page (Override)    baseline_override=${override}    full_page_config=${fpc}    diffing_method=SIMPLE    capture_dom=False
+
+
+    Visual Set Global DiffingMethod    None
+    Visual Set Global CaptureDom    None
+    Visual Set Global BaselineOverride    None
+    Visual Set Global FullPageConfig    None

--- a/visual-python/requirements/dev.txt
+++ b/visual-python/requirements/dev.txt
@@ -1,7 +1,7 @@
 # Development & local build requirements
 -r user.txt
 -r build.txt
-robotframework==7.0.0
-robotframework-seleniumlibrary==6.2.0
+robotframework==7.0.1
+robotframework-seleniumlibrary==6.5.0
 pytest==8.1.1
 coverage==7.4.4

--- a/visual-python/src/saucelabs_visual/frameworks/robot.py
+++ b/visual-python/src/saucelabs_visual/frameworks/robot.py
@@ -7,6 +7,7 @@ from robot.api import logger
 from robot.api.deco import library, keyword
 from robot.libraries.BuiltIn import BuiltIn
 from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
 from saucelabs_visual.client import SauceLabsVisual as Client
 from saucelabs_visual.typing import IgnoreRegion, FullPageConfig, DiffingMethod, DiffingOptions, \
@@ -48,8 +49,8 @@ class SauceLabsVisual:
 
         return BuiltIn().get_library_instance(self.selenium_library_key)
 
-    def _get_selenium_id(self) -> str:
-        return self._get_selenium_library().get_session_id()
+    def _get_driver(self) -> RemoteWebDriver:
+        return self._get_selenium_library().driver
 
     def _parse_full_page_config(self, value: Union[bool, FullPageConfig, dict, str]) -> Union[
         FullPageConfig, None
@@ -251,8 +252,6 @@ class SauceLabsVisual:
             diffing_method: DiffingMethod = DiffingMethod.SIMPLE,
             diffing_options: Union[DiffingOptions, None] = None,
     ):
-        session_id = self._get_selenium_id()
-
         # Robot fails when attempting to parse a TypedDict out of a Union -- and converters are not
         # triggered. So, allow the default value as a string then parse it ourselves to allow us
         # to set proper default / optional values.
@@ -265,7 +264,7 @@ class SauceLabsVisual:
 
         self.client.create_snapshot_from_webdriver(
             name=name,
-            session_id=session_id,
+            driver=self._get_driver(),
             test_name=BuiltIn().get_variable_value('\${TEST NAME}'),
             suite_name=BuiltIn().get_variable_value('\${SUITE NAME}'),
             capture_dom=capture_dom,

--- a/visual-python/src/saucelabs_visual/frameworks/robot.py
+++ b/visual-python/src/saucelabs_visual/frameworks/robot.py
@@ -219,6 +219,22 @@ class SauceLabsVisual:
             disable_only=disable_only,
         )
 
+    @keyword(name="Visual Set Global BaselineOverride")
+    def visual_set_baseline_override(self, baseline_override: Union[BaselineOverride, None]):
+        self.client.baseline_override = baseline_override
+
+    @keyword(name="Visual Set Global CaptureDom")
+    def visual_set_capture_dom(self, capture_dom: Union[bool, None]):
+        self.client.capture_dom = capture_dom
+
+    @keyword(name="Visual Set Global DiffingMethod")
+    def visual_set_diffing_method(self, diffing_method: Union[DiffingMethod, None]):
+        self.client.diffing_method = diffing_method
+
+    @keyword(name="Visual Set Global FullPageConfig")
+    def visual_set_full_page_config(self, full_page_config: Union[FullPageConfig, None]):
+        self.client.full_page_config = full_page_config
+
     @keyword(name="Visual FullPageConfig")
     def visual_full_page_config(
             self,
@@ -265,14 +281,14 @@ class SauceLabsVisual:
             # Robot Framework for free.
             self,
             name: str,
-            capture_dom: bool = False,
+            capture_dom: Union[bool, None] = None,
             clip_selector: Union[str, None] = None,
             clip_element: Union[WebElement, None] = None,
             ignore_regions: List[Union[
                 List[WebElement], IgnoreRegion, str, WebElement, IgnoreElementRegion, dict
             ]] = None,
             full_page_config: Union[FullPageConfig, dict, bool, str, None] = None,
-            diffing_method: DiffingMethod = DiffingMethod.SIMPLE,
+            diffing_method: Union[DiffingMethod, None] = None,
             diffing_options: Union[DiffingOptions, None] = None,
             baseline_override: Union[BaselineOverride, None] = None,
     ):

--- a/visual-python/src/saucelabs_visual/frameworks/robot.py
+++ b/visual-python/src/saucelabs_visual/frameworks/robot.py
@@ -11,7 +11,7 @@ from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
 from saucelabs_visual.client import SauceLabsVisual as Client
 from saucelabs_visual.typing import IgnoreRegion, FullPageConfig, DiffingMethod, DiffingOptions, \
-    IgnoreElementRegion
+    IgnoreElementRegion, BaselineOverride, Browser, OperatingSystem
 from saucelabs_visual.utils import ignore_region_from_dict, is_valid_ignore_region, \
     create_table_from_build_status, is_build_errored, is_build_failed
 
@@ -236,6 +236,29 @@ class SauceLabsVisual:
             scrollLimit=scroll_limit,
         )
 
+    @keyword(name="Visual BaselineOverride")
+    def visual_baseline_override(
+            self,
+            browser: Union[Browser, None] = None,
+            browser_version: Union[str, None] = None,
+            device: Union[str, None] = None,
+            name: Union[str, None] = None,
+            operating_system: Union[OperatingSystem, None] = None,
+            operating_system_version: Union[str, None] = None,
+            suite_name: Union[str, None] = None,
+            test_name: Union[str, None] = None,
+    ):
+        return BaselineOverride(
+            browser=browser,
+            browserVersion=browser_version,
+            device=device,
+            name=name,
+            operatingSystem=operating_system,
+            operatingSystemVersion=operating_system_version,
+            suiteName=suite_name,
+            testName=test_name,
+        )
+
     @keyword(name="Visual Snapshot")
     def visual_snapshot(
             # Params 'duplicated' here, so we get type casting and named parameters provided by
@@ -251,6 +274,7 @@ class SauceLabsVisual:
             full_page_config: Union[FullPageConfig, dict, bool, str, None] = None,
             diffing_method: DiffingMethod = DiffingMethod.SIMPLE,
             diffing_options: Union[DiffingOptions, None] = None,
+            baseline_override: Union[BaselineOverride, None] = None,
     ):
         # Robot fails when attempting to parse a TypedDict out of a Union -- and converters are not
         # triggered. So, allow the default value as a string then parse it ourselves to allow us
@@ -275,6 +299,7 @@ class SauceLabsVisual:
             full_page_config=parsed_fpc,
             diffing_method=diffing_method,
             diffing_options=diffing_options,
+            baseline_override=baseline_override,
         )
 
     @keyword(name="Visual Build Status")

--- a/visual-python/src/saucelabs_visual/typing.py
+++ b/visual-python/src/saucelabs_visual/typing.py
@@ -125,3 +125,34 @@ class BuildStatus(Enum):
     REJECTED = 'REJECTED'
     RUNNING = 'RUNNING'
     UNAPPROVED = 'UNAPPROVED'
+
+
+class Browser(str, Enum):
+    CHROME = 'CHROME'
+    EDGE = 'EDGE'
+    SAFARI = 'SAFARI'
+    FIREFOX = 'FIREFOX'
+    PLAYWRIGHT_WEBKIT = 'PLAYWRIGHT_WEBKIT'
+
+
+class OperatingSystem(str, Enum):
+    ANDROID = 'ANDROID'
+    IOS = 'IOS'
+    LINUX = 'LINUX'
+    MACOS = 'MACOS'
+    WINDOWS = 'WINDOWS'
+
+
+@dataclass
+class BaselineOverride:
+    """
+    One or more keys we should use as an override when matching a baseline.
+    """
+    browser: Union[Browser, None] = None
+    browserVersion: Union[str, None] = None
+    device: Union[str, None] = None
+    name: Union[str, None] = None
+    operatingSystem: Union[OperatingSystem, None] = None
+    operatingSystemVersion: Union[str, None] = None
+    suiteName: Union[str, None] = None
+    testName: Union[str, None] = None


### PR DESCRIPTION
## Description
Adds a few updates to the Visual Python & Robot Framework binding:

- Adds support for baseline overrides / cross browser / os comparisons
- Adds the ability to configure global client options to avoid setting the same setting on every snapshot for the following
  - dom capture
  - baseline overrides
  - diffing method
  - full page config
- Adds RDC support for SauceLabs by forwarding the Job ID from the driver results

## Types of Changes

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
