### PR TITLE
Enhance timeout upload

### DIFF
--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -27,6 +27,7 @@ jobs:
           node-version: 18.x
       - name: Build with lerna
         run: |
+          env
           corepack enable
           yarn install --immutable
           npm run lint --workspaces --if-present

--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -27,9 +27,8 @@ jobs:
           node-version: 18.x
       - name: Build with lerna
         run: |
-          env
           corepack enable
-          yarn install --immutable
+          yarn install
           npm run lint --workspaces --if-present
           npm run build --workspaces --if-present
           npm run test --workspaces --if-present

--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build with lerna
         run: |
           corepack enable
-          yarn install
+          yarn install --immutable
           npm run lint --workspaces --if-present
           npm run build --workspaces --if-present
           npm run test --workspaces --if-present

--- a/visual-js/.changeset/afraid-balloons-brush.md
+++ b/visual-js/.changeset/afraid-balloons-brush.md
@@ -1,0 +1,6 @@
+---
+"@saucelabs/visual": minor
+"@saucelabs/visual-storybook": patch
+---
+
+Debugging info when upload is reaching timeout

--- a/visual-js/visual/src/common/api.ts
+++ b/visual-js/visual/src/common/api.ts
@@ -184,7 +184,7 @@ const uploadToUrl = async ({
       if (ex?.name === 'AbortError') {
         console.error();
         throw new Error(`Uploading snapshot reached timeout.
-Please check that you have connectivity, and are able to do HTTP PUT requests.
+Please check that you have connectivity and are able to do HTTP PUT requests.
 URL: ${uploadUrl}
 Note: This URL is valid only for a couple of minutes`);
       }

--- a/visual-js/visual/src/common/api.ts
+++ b/visual-js/visual/src/common/api.ts
@@ -184,7 +184,7 @@ const uploadToUrl = async ({
       if (ex?.name === 'AbortError') {
         console.error();
         throw new Error(`Uploading snapshot reached timeout.
-Please check that you have connectivity, and are able to do HTTP PUT Requests.
+Please check that you have connectivity, and are able to do HTTP PUT requests.
 URL: ${uploadUrl}
 Note: This URL is valid only for a couple of minutes`);
       }

--- a/visual-js/visual/src/common/api.ts
+++ b/visual-js/visual/src/common/api.ts
@@ -178,16 +178,11 @@ const uploadToUrl = async ({
       throw new Error(`Failed to upload snapshot: ${result.statusText}`);
     }
   } catch (ex: unknown) {
-    const isObject = (value: unknown): value is any =>
-      !!value && typeof value === 'object';
-    if (isObject(ex)) {
-      if (ex?.name === 'AbortError') {
-        console.error();
-        throw new Error(`Uploading snapshot reached timeout.
+    if (String(ex).includes('AbortError')) {
+      throw new Error(`Uploading snapshot reached timeout.
 Please check that you have connectivity and are able to do HTTP PUT requests.
 URL: ${uploadUrl}
 Note: This URL is valid only for a couple of minutes`);
-      }
     }
     throw new Error(`Upload failed with an unknown error: ${ex}`);
   }

--- a/visual-js/visual/src/common/api.ts
+++ b/visual-js/visual/src/common/api.ts
@@ -148,16 +148,19 @@ const uploadToUrl = async ({
   contentType,
   file,
   compress,
+  uploadTimeoutMs,
 }: {
   uploadUrl: string;
   contentType: string;
   file: DataContent | DataPath;
   compress?: boolean;
+  uploadTimeoutMs?: number;
 }) => {
   const uploadBody = isDataPath(file) ? fs.readFileSync(file.path) : file.data;
 
   const hash = crypto.createHash('md5').update(uploadBody).digest('base64');
   try {
+    uploadTimeoutMs ||= 10_000;
     const result = await fetch(uploadUrl, {
       method: 'PUT',
       headers: {
@@ -168,7 +171,7 @@ const uploadToUrl = async ({
       body: uploadBody,
       compress,
       ...fetchOptions,
-      signal: AbortSignal.timeout(2000),
+      signal: AbortSignal.timeout(uploadTimeoutMs),
     });
 
     if (!result.ok) {

--- a/visual-js/yarn.lock
+++ b/visual-js/yarn.lock
@@ -2842,7 +2842,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@saucelabs/cypress-visual-plugin@workspace:visual-cypress"
   dependencies:
-    "@saucelabs/visual": ^0.7.0
+    "@saucelabs/visual": ^0.7.3
     "@tsconfig/node18": ^2.0.1
     "@types/cypress": ^1.1.3
     "@types/node": ^20.4.4
@@ -2920,7 +2920,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@saucelabs/visual@^0.7.0, @saucelabs/visual@workspace:visual":
+"@saucelabs/visual@^0.7.0, @saucelabs/visual@^0.7.3, @saucelabs/visual@workspace:visual":
   version: 0.0.0-use.local
   resolution: "@saucelabs/visual@workspace:visual"
   dependencies:


### PR DESCRIPTION
# Add explicit message when uploads reaches timeout.

> Issue : IRIS-1234

Example in storybook context:
```
  ● Example/Page › Logged In › play-test

    Uploading snapshot reached timeout.
    Please check that you have connectivity and are able to do HTTP PUT requests.
    URL: https://storage.googleapis.com/sauce-iris-prod-us-west4-ybyc/orgs/[orgId]/e4ea0fd1-21ba-4397-ac45-202a41f094f9.png?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=sauce-svc-iris-bucket-prod%40sauce-production-p-i0l6.iam.gserviceaccount.com%2F20240910%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20240910T120018Z&X-Goog-Expires=900&X-Goog-SignedHeaders=content-type%3Bhost&response-content-disposition=attachment&X-Goog-Signature=[SIG]
    Note: This URL is valid only for a couple of minutes

      16864 |       if (ex?.name === "AbortError") {
      16865 |         console.error();
    > 16866 |         throw new Error(`Uploading snapshot reached timeout.
            |               ^
      16867 | Please check that you have connectivity and are able to do HTTP PUT requests.
      16868 | URL: ${uploadUrl}
      16869 | Note: This URL is valid only for a couple of minutes`);

      at uploadToUrl (../visual-sdks/visual-js/visual/build/index.cjs:16866:15)
      at Object.uploadSnapshot (../visual-sdks/visual-js/visual/build/index.cjs:16888:5)
      at postVisit (storybook/node_modules/@saucelabs/visual-storybook/build/index.cjs:332:20)
      at testFn (../../../../../private/var/folders/p0/6kkfxbnd1lz84fg_ck1jnmfc0000gn/T/29d28a7bd3b1e4861e377e4b1f87919f/example-page.test.js:65:11)
      at Object.<anonymous> (../../../../../private/var/folders/p0/6kkfxbnd1lz84fg_ck1jnmfc0000gn/T/29d28a7bd3b1e4861e377e4b1f87919f/example-page.test.js:79:9)

Test Suites: 18 failed, 18 of 3 total```

## Description
Adds a controlled timeout  (default: 10s) that will be used to communicate with the user when upload is taking too much time.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
