### PR TITLE
[Cypress] Ensure all statuses are available in `sauceVisualResult` summary

### DIFF
--- a/visual-js/.changeset/slow-seas-occur.md
+++ b/visual-js/.changeset/slow-seas-occur.md
@@ -1,0 +1,10 @@
+---
+"@saucelabs/cypress-visual-plugin": patch
+"@saucelabs/visual": patch
+"@saucelabs/nightwatch-sauce-visual-service": patch
+"@saucelabs/visual-playwright": patch
+"@saucelabs/visual-storybook": patch
+"@saucelabs/wdio-sauce-visual-service": patch
+---
+
+Fill out statuses in sauceVisualResults for cypress

--- a/visual-js/.changeset/slow-seas-occur.md
+++ b/visual-js/.changeset/slow-seas-occur.md
@@ -8,3 +8,4 @@
 ---
 
 Fill out statuses in sauceVisualResults for cypress
+Bump all dependencies to use new ignore region calculation system

--- a/visual-js/visual-cypress/src/index.ts
+++ b/visual-js/visual-cypress/src/index.ts
@@ -272,7 +272,14 @@ Sauce Labs Visual: Unable to create new build.
 
     const filterDiffsById = (diff: { id: string; status: DiffStatus }) =>
       this.uploadedDiffIds.includes(diff.id);
-    const initialStatusSummary = {} as Record<DiffStatus, number>;
+    const initialStatusSummary = {
+      [DiffStatus.Queued]: 0,
+      [DiffStatus.Unapproved]: 0,
+      [DiffStatus.Approved]: 0,
+      [DiffStatus.Equal]: 0,
+      [DiffStatus.Errored]: 0,
+      [DiffStatus.Rejected]: 0,
+    } satisfies Record<DiffStatus, number>;
     const statusSummary = diffsForTestResult.nodes
       .filter(filterDiffsById)
       .reduce((statusSummary, diff) => {


### PR DESCRIPTION
## Description
Our [docs](https://docs.saucelabs.com/visual-testing/integrations/cypress/#test-results-summary) say you can use the sauceVisualResult summary to check the status of a result and assert that a certain status is never found. Currently, however, that object is empty so asserting `unapproved = 0` would never pass. 

This PR does the following:

- This updates the check to populate all the keys of our DiffStatus into the initial value before reducing over the nodes.
- This also bumps all other bindings by a patch to roll out the new server-side ignore region calculation.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)

