### PR TITLE
[C#] Disable nullish coalescing to empty strings in ENV

### DIFF
--- a/visual-dotnet/SauceLabs.Visual/Utils/EnvVars.cs
+++ b/visual-dotnet/SauceLabs.Visual/Utils/EnvVars.cs
@@ -4,17 +4,17 @@ namespace SauceLabs.Visual.Utils
 {
     internal class EnvVars
     {
-        internal static string Project => Environment.GetEnvironmentVariable("SAUCE_VISUAL_PROJECT") ?? "";
-        internal static string Branch => Environment.GetEnvironmentVariable("SAUCE_VISUAL_BRANCH") ?? "";
+        internal static string? Project => Environment.GetEnvironmentVariable("SAUCE_VISUAL_PROJECT");
+        internal static string? Branch => Environment.GetEnvironmentVariable("SAUCE_VISUAL_BRANCH");
 
-        internal static string DefaultBranch =>
-            Environment.GetEnvironmentVariable("SAUCE_VISUAL_DEFAULT_BRANCH") ?? "";
+        internal static string? DefaultBranch =>
+            Environment.GetEnvironmentVariable("SAUCE_VISUAL_DEFAULT_BRANCH");
 
         internal static string BuildName => Environment.GetEnvironmentVariable("SAUCE_VISUAL_BUILD_NAME") ?? "";
-        internal static string CustomId => Environment.GetEnvironmentVariable("SAUCE_VISUAL_CUSTOM_ID") ?? "";
-        internal static string BuildId => Environment.GetEnvironmentVariable("SAUCE_VISUAL_BUILD_ID") ?? "";
-        internal static string Username => Environment.GetEnvironmentVariable("SAUCE_USERNAME") ?? "";
-        internal static string AccessKey => Environment.GetEnvironmentVariable("SAUCE_ACCESS_KEY") ?? "";
-        internal static string Region => Environment.GetEnvironmentVariable("SAUCE_REGION") ?? "";
+        internal static string? CustomId => Environment.GetEnvironmentVariable("SAUCE_VISUAL_CUSTOM_ID");
+        internal static string? BuildId => Environment.GetEnvironmentVariable("SAUCE_VISUAL_BUILD_ID");
+        internal static string? Username => Environment.GetEnvironmentVariable("SAUCE_USERNAME");
+        internal static string? AccessKey => Environment.GetEnvironmentVariable("SAUCE_ACCESS_KEY");
+        internal static string? Region => Environment.GetEnvironmentVariable("SAUCE_REGION");
     }
 }


### PR DESCRIPTION
## Description
Disables nullish coalescing of empty strings during ENV parsing. Since null values from ENVs were coalesced to empty strings `""` these would be sent to the GraphQL API and stored with the corresponding build / snapshot. This is especially problematic for custom IDs which are used as a grouping behavior for builds and can be easily done unintentionally with the current behavior.

Project / Branches are coalesced to empty strings before hashing in the backend which should make this backwards compatible for baseline hash matching.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
