### PR TITLE
[Cypress] Allow multiple elements in ignoreRegions

### DIFF
--- a/visual-js/.changeset/old-mails-sin.md
+++ b/visual-js/.changeset/old-mails-sin.md
@@ -1,0 +1,5 @@
+---
+"@saucelabs/cypress-visual-plugin": patch
+---
+
+fix ignore regions for multiple elements

--- a/visual-js/visual-cypress/src/commands.ts
+++ b/visual-js/visual-cypress/src/commands.ts
@@ -92,19 +92,13 @@ function chainableWaitForAll<S>(
 ): Cypress.Chainable<S[]> {
   const result: S[] = [];
 
-  if (list.length < 1) return cy.wrap<S[]>([]);
-
-  let curChainable = list[0];
-  for (let idx = 1; idx < list.length; idx++) {
-    curChainable = curChainable.then((resolved) => {
-      result.push(resolved);
-      return list[idx];
+  list.forEach((item) => {
+    item.then((el) => {
+      result.push(el);
     });
-  }
-  return curChainable.then((item) => {
-    result.push(item);
-    return result;
   });
+
+  return cy.wrap(result);
 }
 
 const sauceVisualCheckCommand = (


### PR DESCRIPTION
## Description
Iterates over passed cypress chainables and yields the results in an array.

Example of multiple ignorables:

```js
cy.sauceVisualCheck('Inventory Page', {
  captureDom: true,
  ignoredRegions: [
    cy.get('.inventory_item_price'),
    cy.get('.btn_inventory'),
    cy.get('.inventory_item_name'),
    cy.get('.bm-burger-button'),
    cy.get('img.inventory_item_img'),
    {
      x: 50,
      y: 50,
      width: 100,
      height: 100,
    }
  ],
});
```

Results in UI:

![image](https://github.com/user-attachments/assets/978f219b-e81f-4fdf-be19-f97d81dc4a53)



## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)

