### PR TITLE
[Cypress] Augment types to better support TypeScript Cypress configurations

### DIFF
--- a/visual-js/.changeset/tricky-pandas-doubt.md
+++ b/visual-js/.changeset/tricky-pandas-doubt.md
@@ -1,0 +1,5 @@
+---
+"@saucelabs/cypress-visual-plugin": patch
+---
+
+update types, fix devdep

--- a/visual-js/visual-cypress/package.json
+++ b/visual-js/visual-cypress/package.json
@@ -41,8 +41,7 @@
     "chalk": "^5.3.0",
     "exponential-backoff": "^3.1.1",
     "macos-release": "^3.2.0",
-    "node-fetch": "^3.3.1",
-    "tsup": "^7.2.0"
+    "node-fetch": "^3.3.1"
   },
   "tsup": {
     "entry": [
@@ -74,6 +73,7 @@
     "prettier": "^2.8.8",
     "ts-node": "^10.9.1",
     "tsc-watch": "^6.0.4",
+    "tsup": "^7.2.0",
     "typescript": "^5.1.6"
   },
   "scripts": {

--- a/visual-js/visual-cypress/src/commands.ts
+++ b/visual-js/visual-cypress/src/commands.ts
@@ -10,6 +10,7 @@
 import {
   PlainRegion,
   ResolvedVisualRegion,
+  SauceConfig,
   SauceVisualViewport,
   ScreenshotMetadata,
   VisualCheckOptions,
@@ -33,6 +34,9 @@ declare global {
       ): Chainable<Subject>;
 
       sauceVisualResults(): Chainable<Subject>;
+    }
+    interface EndToEndConfigOptions {
+      saucelabs: SauceConfig;
     }
   }
 }

--- a/visual-js/yarn.lock
+++ b/visual-js/yarn.lock
@@ -3532,7 +3532,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@saucelabs/cypress-visual-plugin@workspace:visual-cypress"
   dependencies:
-    "@saucelabs/visual": ^0.8.3
+    "@saucelabs/visual": ^0.9.0
     "@tsconfig/node18": ^2.0.1
     "@types/cypress": ^1.1.3
     "@types/node": ^20.4.4
@@ -3561,7 +3561,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@saucelabs/nightwatch-sauce-visual-service@workspace:visual-nightwatch"
   dependencies:
-    "@saucelabs/visual": ^0.8.3
+    "@saucelabs/visual": ^0.9.0
     "@types/mocha": ^10.0.6
     "@typescript-eslint/parser": ^7.11.0
     chalk: ^4.1.2
@@ -3577,13 +3577,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@saucelabs/visual-playwright@^0.1.3, @saucelabs/visual-playwright@workspace:visual-playwright":
+"@saucelabs/visual-playwright@^0.1.4, @saucelabs/visual-playwright@workspace:visual-playwright":
   version: 0.0.0-use.local
   resolution: "@saucelabs/visual-playwright@workspace:visual-playwright"
   dependencies:
     "@jest/globals": ^28.0.0 || ^29.0.0
     "@playwright/test": ^1.42.1
-    "@saucelabs/visual": ^0.8.3
+    "@saucelabs/visual": ^0.9.0
     "@storybook/types": ^8.0.2
     "@tsconfig/node18": ^2.0.0
     "@types/node": ^18.13.0
@@ -3612,8 +3612,8 @@ __metadata:
   resolution: "@saucelabs/visual-storybook@workspace:visual-storybook"
   dependencies:
     "@jest/globals": ^28.0.0 || ^29.0.0
-    "@saucelabs/visual": ^0.8.3
-    "@saucelabs/visual-playwright": ^0.1.3
+    "@saucelabs/visual": ^0.9.0
+    "@saucelabs/visual-playwright": ^0.1.4
     "@storybook/test-runner": ">=0.13.0"
     "@storybook/types": ^8.0.2
     "@tsconfig/node18": ^2.0.0
@@ -3642,7 +3642,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@saucelabs/visual@^0.8.3, @saucelabs/visual@workspace:visual":
+"@saucelabs/visual@^0.9.0, @saucelabs/visual@workspace:visual":
   version: 0.0.0-use.local
   resolution: "@saucelabs/visual@workspace:visual"
   dependencies:
@@ -3688,7 +3688,7 @@ __metadata:
   resolution: "@saucelabs/wdio-sauce-visual-service@workspace:visual-wdio"
   dependencies:
     "@jest/globals": ^29.7.0
-    "@saucelabs/visual": ^0.8.3
+    "@saucelabs/visual": ^0.9.0
     "@tsconfig/node18": ^2.0.0
     "@types/jest": ^29.5.6
     "@typescript-eslint/eslint-plugin": ^5.59.1


### PR DESCRIPTION
## Description
Updates the type exported from our plugin and recommended in our documentation to add the `saucelabs` key to the Cypress configuration object. Enables better TypeScript support when running / configuring Cypress under a TypeScript project. Also moves a devdependency to the correct location in package.json.

![image](https://github.com/user-attachments/assets/23e2cdf5-a2fc-4f15-a12c-4e4d4c675d81)


## Types of Changes
- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements
