### PR TITLE
[Playwright] Fix ignore region positioning when clipSelector is also present

### DIFF
--- a/visual-js/.changeset/five-monkeys-live.md
+++ b/visual-js/.changeset/five-monkeys-live.md
@@ -1,0 +1,6 @@
+---
+"@saucelabs/visual-playwright": patch
+"@saucelabs/visual-storybook": patch
+---
+
+fix ignore region positioning when clipSelector is also present


### PR DESCRIPTION
## Description
This updates the ignore regions position using the offset of the clipped element, if present, for Playwright + Storybook.

Example from Sauce Demo site: 

![image](https://github.com/user-attachments/assets/a7f2b196-b337-402d-8b22-6cb32d1fc468)


## Types of Changes

- Bug fix (non-breaking change which fixes an issue)