### PR TITLE
[Storybook] Add ability to auto capture variations of a Story

### DIFF
--- a/visual-js/.changeset/tender-turkeys-divide.md
+++ b/visual-js/.changeset/tender-turkeys-divide.md
@@ -1,0 +1,5 @@
+---
+"@saucelabs/visual-storybook": minor
+---
+
+add ability to test variations of a story using overridable args

--- a/visual-js/visual-storybook/package.json
+++ b/visual-js/visual-storybook/package.json
@@ -48,8 +48,8 @@
     "jest-playwright-preset": "^2.0.0 || ^3.0.0"
   },
   "peerDependencies": {
-    "storybook": "^7.0.0 || ^8.0.0",
-    "@storybook/core": "^7.0.0 || ^8.0.0"
+    "@storybook/core": "^7.0.0 || ^8.0.0",
+    "storybook": "^7.0.0 || ^8.0.0"
   },
   "tsup": {
     "entry": [

--- a/visual-js/visual-storybook/package.json
+++ b/visual-js/visual-storybook/package.json
@@ -48,7 +48,8 @@
     "jest-playwright-preset": "^2.0.0 || ^3.0.0"
   },
   "peerDependencies": {
-    "storybook": "^7.0.0 || ^8.0.0"
+    "storybook": "^7.0.0 || ^8.0.0",
+    "@storybook/core": "^7.0.0 || ^8.0.0"
   },
   "tsup": {
     "entry": [

--- a/visual-js/visual-storybook/src/api.ts
+++ b/visual-js/visual-storybook/src/api.ts
@@ -2,7 +2,10 @@ import type { TestContext } from '@storybook/test-runner';
 import { getStoryContext } from '@storybook/test-runner';
 import type { Page } from 'playwright-core';
 import { internals } from '@saucelabs/visual-playwright';
-import { SauceVisualParams } from './types';
+import { SauceVisualParams, StoryContext, StoryVariation } from './types';
+import events from '@storybook/core/core-events';
+
+import type EventEmitter from 'node:events';
 
 const { VisualPlaywright } = internals;
 
@@ -13,20 +16,19 @@ export const VisualStorybook = new VisualPlaywright(
 );
 
 /**
- * Used in Storybook's test runner config file (test-runner.js/ts) for the `postVisit` hook. Takes
- * a snapshot of the current viewport and uploads it to Sauce Visual.
+ * Proxy Storybook information to take Playwright snapshots with the appropriate metadata. Internal.
+ * @param context
+ * @param params
  */
-export const postVisit = async (page: Page, context: TestContext) => {
-  const storyContext = await getStoryContext(page, context);
-  const sauceVisualParams = storyContext.parameters.sauceVisual as
-    | Partial<SauceVisualParams>
-    | undefined;
+const takeScreenshot = async (
+  context: StoryContext,
+  params: Partial<SauceVisualParams> | undefined,
+) => {
   const {
     clip: shouldClip = true,
     clipSelector = '#storybook-root',
     ...otherOptions
-  } = sauceVisualParams ?? {};
-
+  } = params ?? {};
   await VisualStorybook.takePlaywrightScreenshot(
     page,
     {
@@ -41,6 +43,96 @@ export const postVisit = async (page: Page, context: TestContext) => {
       ...otherOptions,
     },
   );
+};
+
+/**
+ * Augment story names when creating visual variations.
+ * @param context
+ * @param variation
+ */
+export const augmentStoryName = (
+  context: StoryContext,
+  variation: StoryVariation,
+): StoryContext => {
+  const { id, title } = context;
+  let { name } = context;
+
+  if (variation.name) {
+    name = variation.name;
+  }
+
+  if (variation.prefix) {
+    name = `${variation.prefix}${name}`;
+  }
+
+  if (variation.postfix) {
+    name = `${variation.postfix}${name}`;
+  }
+
+  return {
+    id,
+    title,
+    name,
+  };
+};
+
+/**
+ * Used in Storybook's test runner config file (test-runner.js/ts) for the `postVisit` hook. Takes
+ * a snapshot of the current viewport and uploads it to Sauce Visual.
+ */
+export const postVisit = async (page: Page, context: TestContext) => {
+  const storyContext = await getStoryContext(page, context);
+  const sauceVisualParams = storyContext.parameters.sauceVisual as
+    | Partial<SauceVisualParams>
+    | undefined;
+  const variations = sauceVisualParams?.variations;
+
+  await takeScreenshot(storyContext, sauceVisualParams);
+
+  if (variations) {
+    const storyId = storyContext.id;
+    const args = storyContext.initialArgs;
+
+    for (const variation of variations) {
+      await page.evaluate(
+        ({ variation, events, storyId }) => {
+          // @ts-expect-error Global managed by Storybook.
+          const channel: EventEmitter = globalThis.__STORYBOOK_ADDONS_CHANNEL__;
+          if (!channel) {
+            throw new Error(
+              'The test runner could not access the Storybook channel. Are you sure the Storybook is running correctly in that URL?',
+            );
+          }
+
+          const { args } = variation;
+
+          // Reset values to default
+          channel.emit(events['RESET_STORY_ARGS'], { storyId });
+
+          // Then update them with the requested values
+          if (args) {
+            channel.emit(events['UPDATE_STORY_ARGS'], {
+              storyId,
+              updatedArgs: {
+                ...args,
+              },
+            });
+          }
+        },
+        {
+          variation,
+          events,
+          storyId,
+          args,
+        },
+      );
+
+      await takeScreenshot(
+        augmentStoryName(storyContext, variation),
+        sauceVisualParams,
+      );
+    }
+  }
 };
 
 /**

--- a/visual-js/visual-storybook/src/index.ts
+++ b/visual-js/visual-storybook/src/index.ts
@@ -1,3 +1,3 @@
 export { postRender, postVisit } from './api';
 export { getVisualTestConfig } from './config';
-export type { SauceVisualParams } from './types';
+export type { SauceVisualParams, ArgsTypes, StoryVariation } from './types';

--- a/visual-js/visual-storybook/src/types.ts
+++ b/visual-js/visual-storybook/src/types.ts
@@ -20,9 +20,43 @@ export interface VisualOpts extends PlaywrightParams {
   customId: string | null;
 }
 
-export interface SauceVisualParams extends PlaywrightParams {
+export interface ArgsTypes {
+  [key: string]: any;
+}
+
+export interface StoryVariation<Args = ArgsTypes> {
+  /**
+   * A string to prepend prior to the story name when taking a snapshot.
+   */
+  prefix?: string;
+  /**
+   * A string to append after the story name when taking a snapshot.
+   */
+  postfix?: string;
+  /**
+   * One or more Args to overwrite in your Storybook stories. Will take a screenshot for each
+   * requested variation and upload it to Sauce Labs.
+   */
+  args?: Args;
+  /**
+   * A name to optionally use instead of the default story name.
+   */
+  name?: string;
+}
+
+export interface SauceVisualParams<Args = ArgsTypes> extends PlaywrightParams {
   /**
    * Whether we should clip the story reduce whitespaces in snapshots.
    */
   clip?: boolean;
+  /**
+   * Variations of the current story we should take in addition to the default state.
+   */
+  variations?: StoryVariation<Args>[];
+}
+
+export interface StoryContext {
+  id: string;
+  title: string;
+  name: string;
 }

--- a/visual-js/yarn.lock
+++ b/visual-js/yarn.lock
@@ -3090,6 +3090,7 @@ __metadata:
     tsup: ^7.2.0
     typescript: ^5.0.4
   peerDependencies:
+    "@storybook/core": ^7.0.0 || ^8.0.0
     storybook: ^7.0.0 || ^8.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

This PR adds the ability to test additional variations of a story by supplying custom args which will be appended to the initial args state prior to each capture. For example, you could have a single Storybook Story with a `Button` component with controls to toggle the `size` and `primary` props so users could see the story in their playground and still take snapshots of each state.

With that example, here we could have a single Story to not clutter the UI, but still take snapshots of numerous states when using Sauce Visual. Below tests numerous size, disabled, and primary states. Each `StoryVariation` allows customizing the name and overriding the args for a story. It will reset the args to the default `initialArgs` state prior to each snapshot variation.

See the `parameters.sauceVisual.variations` property below.

```tsx
const meta = {
  title: "Example/Button",
  component: Button,
  parameters: {
    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
    layout: "centered",
    sauceVisual: {
      variations: [
        {
          prefix: '[disabled] ',
          args: {
            disabled: true,
          },
        },
        {
          prefix: '[small] ',
          args: {
            size: "small",
          },
        },
        {
          prefix: '[medium] ',
          args: {
            size: "medium",
          },
        },
        {
          prefix: '[large] ',
          args: {
            size: "large",
          },
        },
        {
          prefix: 'Primary ',
          args: {
            primary: true,
          },
        },
      ],
    } satisfies SauceVisualParams,
  },
  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
  argTypes: {
    backgroundColor: { control: "color" },
  },
} satisfies Meta<typeof Button>;
```

Output of this example in the UI. Though difficult to see in this preview since the thumbnails stretch to fit the cards, each button has a different size depending on the 'size' prop, as well as the values of the primary / disabled props.

![image](https://github.com/user-attachments/assets/5350213a-7048-4402-bf4c-88f544fafc5c)


## Types of Changes

- New feature (non-breaking change which adds functionality)