### PR TITLE
[Playwright] Fix ignore region & clip positioning when page is scrolled prior to snapshot

### DIFF
--- a/visual-js/.changeset/spotty-pumpkins-hide.md
+++ b/visual-js/.changeset/spotty-pumpkins-hide.md
@@ -1,0 +1,5 @@
+---
+"@saucelabs/visual-playwright": patch
+---
+
+Correct clipping and ignore regions when page is pre-scrolled

--- a/visual-js/visual-playwright/src/api.ts
+++ b/visual-js/visual-playwright/src/api.ts
@@ -193,6 +193,12 @@ ${e instanceof Error ? e.message : JSON.stringify(e)}
             const clientDims = clipElement.getBoundingClientRect();
             let { x, y, height, width } = clientDims;
 
+            // Add scroll offset to coordinates in case page is scrolled prior to capture
+            ({ x, y } = {
+              x: x + window.scrollX,
+              y: y + window.scrollY,
+            });
+
             // corrected coordinates
             const cX = x < 0 ? Math.abs(x) : 0;
             const cY = y < 0 ? Math.abs(y) : 0;
@@ -243,8 +249,8 @@ ${e instanceof Error ? e.message : JSON.stringify(e)}
 
                 selectorRegions.push({
                   name: selector,
-                  x: Math.round(rect.x),
-                  y: Math.round(rect.y),
+                  x: Math.round(rect.x + window.scrollX),
+                  y: Math.round(rect.y + window.scrollY),
                   height: Math.round(rect.height),
                   width: Math.round(rect.width),
                 });


### PR DESCRIPTION
## Description
Offsets the ignore region & clip calculation with the current scroll offset on the window

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)

Before:

![Screenshot 2025-02-19 at 12 16 02](https://github.com/user-attachments/assets/b6770186-5ac2-4c38-87c0-9c76f829add7)

After:

![Screenshot 2025-02-19 at 12 16 17](https://github.com/user-attachments/assets/ac55fee7-bf8d-474e-8694-13d3496f731b)

