### PR TITLE
visual-js: fix visual-cypress build error

### DIFF
--- a/visual-js/visual-cypress/integration-tests/tsconfig.json
+++ b/visual-js/visual-cypress/integration-tests/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
+    "moduleResolution": "Node16",
     "lib": [
       "ES2020",
       "dom"


### PR DESCRIPTION
# Fix `visual-cypress` build error

## Description
When running `npm run login-test` in `visual-cypress/integration-tests`, an error is shown:

```
Error: Webpack Compilation Error
[tsl] ERROR
      TS5109: Option 'moduleResolution' must be set to 'Node16' (or left unspecified) when option 'module' is set to 'Node16'.
```

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)
