### PR TITLE
[no-ticket] Do not create a build when there are no files to process

### DIFF
--- a/visual-js/.changeset/forty-bees-sin.md
+++ b/visual-js/.changeset/forty-bees-sin.md
@@ -1,0 +1,5 @@
+---
+"@saucelabs/visual-snapshots": minor
+---
+
+Reasonable defaults for build name, suite name, test name, and snapshot name

--- a/visual-js/visual-snapshots/src/app/pdf-handler.ts
+++ b/visual-js/visual-snapshots/src/app/pdf-handler.ts
@@ -3,8 +3,10 @@ import {
   VisualSnapshotsApi,
 } from "../api/visual-snapshots-api.js";
 import { VisualConfig } from "@saucelabs/visual";
-import { getFiles } from "../utils/glob.js";
 import { PdfSnapshotUploader } from "./pdf-files-snapshot-uploader.js";
+import { logger as defaultLogger } from "../logger.js";
+import { FileExtractor } from "../utils/glob.js";
+import { Logger } from "pino";
 
 export interface PdfCommandParams
   extends VisualConfig,
@@ -15,14 +17,30 @@ export interface PdfCommandParams
 export class PdfCommandHandler {
   constructor(
     private readonly visualSnapshotsApi: VisualSnapshotsApi,
-    private readonly pdfSnapshotUploader: PdfSnapshotUploader
+    private readonly pdfSnapshotUploader: PdfSnapshotUploader,
+    private readonly fileExtractor: FileExtractor,
+    private readonly logger: Logger = defaultLogger
   ) {}
 
   public async handle(
     globsOrDirs: string[],
     params: PdfCommandParams
   ): Promise<void> {
-    const pdfFilePaths = await getFiles(globsOrDirs, "*.pdf");
+    const pdfFilePaths = await this.fileExtractor.getFiles(
+      globsOrDirs,
+      "*.pdf"
+    );
+
+    if (pdfFilePaths.length === 0) {
+      this.logger.warn("No PDF files found to process.");
+      return;
+    }
+
+    this.logger.info(
+      `Found ${pdfFilePaths.length} PDF file${
+        pdfFilePaths.length > 1 ? "s" : ""
+      } to process: ${pdfFilePaths.join(", ")}`
+    );
 
     const buildId =
       params.buildId ?? (await this.visualSnapshotsApi.createBuild(params));

--- a/visual-js/visual-snapshots/src/app/pdf-handler.ts
+++ b/visual-js/visual-snapshots/src/app/pdf-handler.ts
@@ -37,9 +37,11 @@ export class PdfCommandHandler {
     }
 
     this.logger.info(
-      `Found ${pdfFilePaths.length} PDF file${
-        pdfFilePaths.length > 1 ? "s" : ""
-      } to process: ${pdfFilePaths.join(", ")}`
+      {
+        count: pdfFilePaths.length,
+        paths: pdfFilePaths,
+      },
+      `Found PDF file${pdfFilePaths.length > 1 ? "s" : ""} to process`
     );
 
     const buildId =

--- a/visual-js/visual-snapshots/src/commands/pdf.ts
+++ b/visual-js/visual-snapshots/src/commands/pdf.ts
@@ -20,6 +20,7 @@ import { initializeVisualApi } from "../api/visual-client.js";
 import { WorkerPoolPdfSnapshotUploader } from "../app/worker/worker-pool-pdf-snapshot-uploader.js";
 import { LibPdfFileLoader } from "../app/pdf-file-loader.js";
 import { logger } from "../logger.js";
+import { GlobFileExtractor } from "../utils/glob.js";
 
 export const pdfCommand = (clientVersion: string) => {
   return new Command()
@@ -52,12 +53,14 @@ export const pdfCommand = (clientVersion: string) => {
           maxWorkers: params.concurrency,
         }
       );
+      const globFileExtractor = new GlobFileExtractor();
 
-      new PdfCommandHandler(visualSnapshotsApi, pdfSnapshotUploader)
+      new PdfCommandHandler(
+        visualSnapshotsApi,
+        pdfSnapshotUploader,
+        globFileExtractor
+      )
         .handle(globsOrDirs, params)
-        .then(() => {
-          logger.info("Successfully created PDF snapshots.");
-        })
         .catch((err) => {
           logger.error(err, "At least one PDF snapshot creation failed.");
         });

--- a/visual-js/visual-snapshots/src/utils/glob.ts
+++ b/visual-js/visual-snapshots/src/utils/glob.ts
@@ -2,27 +2,35 @@ import { glob } from "glob";
 import fs from "fs/promises";
 import path from "path";
 
-/**
- * Returns all files matched by globs, or if path is a directory, matched by `dirGlob`.
- * @param globOrDirs Globs or dirs to get files from.
- * @param dirGlob Glob to append to directory path.
- * @returns Matched files.
- */
-export async function getFiles(globOrDirs: string[], dirGlob: string) {
-  const globs = await Promise.all(
-    globOrDirs.map((g) =>
-      isDirectory(g).then((result) => (result ? path.join(g, dirGlob) : g))
-    )
-  );
-
-  return await glob(globs);
+export interface FileExtractor {
+  getFiles(globOrDirs: string[], dirGlob: string): Promise<string[]>;
 }
 
-async function isDirectory(path: string) {
-  try {
-    const stat = await fs.stat(path);
-    return stat.isDirectory();
-  } catch {
-    return false;
+export class GlobFileExtractor implements FileExtractor {
+  /**
+   * Returns all files matched by globs, or if path is a directory, matched by `dirGlob`.
+   * @param globOrDirs Globs or dirs to get files from.
+   * @param dirGlob Glob to append to directory path.
+   * @returns Matched files.
+   */
+  public async getFiles(globOrDirs: string[], dirGlob: string) {
+    const globs = await Promise.all(
+      globOrDirs.map((g) =>
+        this.isDirectory(g).then((result) =>
+          result ? path.join(g, dirGlob) : g
+        )
+      )
+    );
+
+    return await glob(globs);
+  }
+
+  private async isDirectory(path: string) {
+    try {
+      const stat = await fs.stat(path);
+      return stat.isDirectory();
+    } catch {
+      return false;
+    }
   }
 }

--- a/visual-js/visual-snapshots/test/api/visual-api.spec.ts
+++ b/visual-js/visual-snapshots/test/api/visual-api.spec.ts
@@ -4,7 +4,7 @@ import {
   UploadSnapshotParams,
   VisualSnapshotsApi,
 } from "../../src/api/visual-snapshots-api.js";
-import { mockLogger } from "../helpers.js";
+import { mockLogger } from "../mock-logger.js";
 
 describe("VisualSnapshots", () => {
   const { logger, logged, reset: resetLogger } = mockLogger();

--- a/visual-js/visual-snapshots/test/api/worker/pdf-page-snapshot-uploader.spec.ts
+++ b/visual-js/visual-snapshots/test/api/worker/pdf-page-snapshot-uploader.spec.ts
@@ -17,10 +17,6 @@ function createUploadId(content: Buffer) {
 
 describe("PdfPageSnapshotUploader", () => {
   describe("uploadPageSnapshot", () => {
-    const consoleInfoSpy = jest
-      .spyOn(console, "info")
-      .mockImplementation(() => undefined);
-
     const uploadImageAndCreateSnapshot = jest.fn<
       ReturnType<VisualSnapshotsApi["uploadImageAndCreateSnapshot"]>,
       Parameters<VisualSnapshotsApi["uploadImageAndCreateSnapshot"]>
@@ -59,8 +55,6 @@ describe("PdfPageSnapshotUploader", () => {
       uploadImageAndCreateSnapshot.mockImplementation(({ snapshot }) =>
         Promise.resolve(createUploadId(snapshot))
       );
-
-      consoleInfoSpy.mockReset();
     });
 
     it("should call uploadImageAndCreateSnapshot", async () => {

--- a/visual-js/visual-snapshots/test/app/__snapshots__/pdf-handler.spec.ts.snap
+++ b/visual-js/visual-snapshots/test/app/__snapshots__/pdf-handler.spec.ts.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pdf-handler creating build should create a build when buildId is not passed 1`] = `
+[
+  {
+    "count": 2,
+    "level": 30,
+    "msg": "Found PDF files to process",
+    "paths": [
+      "/absolute/path/to/files/1.pdf",
+      "/absolute/path/to/files/2.pdf",
+    ],
+  },
+]
+`;
+
+exports[`pdf-handler creating build should not create a build when buildId is passed 1`] = `
+[
+  {
+    "count": 1,
+    "level": 30,
+    "msg": "Found PDF file to process",
+    "paths": [
+      "/absolute/path/to/files/1.pdf",
+    ],
+  },
+]
+`;
+
+exports[`pdf-handler creating build should not create a build when there are no files to process 1`] = `
+[
+  {
+    "level": 40,
+    "msg": "No PDF files found to process.",
+  },
+]
+`;

--- a/visual-js/visual-snapshots/test/app/pdf-file-loader.spec.ts
+++ b/visual-js/visual-snapshots/test/app/pdf-file-loader.spec.ts
@@ -1,5 +1,5 @@
 import { LibPdfFileLoader } from "../../src/app/pdf-file-loader.js";
-import { __dirname } from "../helpers.js";
+import { __dirname } from "../system-helpers.js";
 
 describe("LibPdfFileLoader", () => {
   it("should call library with path and scale", async () => {

--- a/visual-js/visual-snapshots/test/app/pdf-handler.spec.ts
+++ b/visual-js/visual-snapshots/test/app/pdf-handler.spec.ts
@@ -38,18 +38,19 @@ describe("pdf-handler", () => {
   const snapshotName = "snapshotName";
   const buildId = "buildId";
 
-  const fileExtractor = new MockFileExtractor();
+  const mockFileExtractor = new MockFileExtractor();
 
   const { logger, logged, reset: resetLogger } = mockLogger();
 
   beforeEach(() => {
     jest.resetAllMocks();
     resetLogger();
+    mockFileExtractor.reset();
   });
 
   describe("creating build", () => {
     it("should create a build when buildId is not passed", async () => {
-      fileExtractor.setFilesToReturn([
+      mockFileExtractor.setFilesToReturn([
         "/absolute/path/to/files/1.pdf",
         "/absolute/path/to/files/2.pdf",
       ]);
@@ -57,7 +58,7 @@ describe("pdf-handler", () => {
       const handler = new PdfCommandHandler(
         visualSnapshotsApi,
         pdfSnapshotUploaderMock,
-        fileExtractor,
+        mockFileExtractor,
         logger
       );
 
@@ -74,6 +75,12 @@ describe("pdf-handler", () => {
       );
 
       expect(createBuildMock).toHaveBeenCalledWith(params);
+      expect(mockFileExtractor.calls()).toEqual([
+        {
+          globOrDirs: [path.join(__dirname(import.meta), "../files/")],
+          dirGlob: "*.pdf",
+        },
+      ]);
       expect(logged).toEqual([
         {
           level: 30,
@@ -83,12 +90,12 @@ describe("pdf-handler", () => {
     });
 
     it("should not create a build when buildId is passed", async () => {
-      fileExtractor.setFilesToReturn(["/absolute/path/to/files/1.pdf"]);
+      mockFileExtractor.setFilesToReturn(["/absolute/path/to/files/1.pdf"]);
 
       const handler = new PdfCommandHandler(
         visualSnapshotsApi,
         pdfSnapshotUploaderMock,
-        fileExtractor,
+        mockFileExtractor,
         logger
       );
 
@@ -106,6 +113,12 @@ describe("pdf-handler", () => {
       );
 
       expect(createBuildMock).not.toHaveBeenCalled();
+      expect(mockFileExtractor.calls()).toEqual([
+        {
+          globOrDirs: [path.join(__dirname(import.meta), "../files/1.pdf")],
+          dirGlob: "*.pdf",
+        },
+      ]);
       expect(logged).toEqual([
         {
           level: 30,
@@ -115,12 +128,12 @@ describe("pdf-handler", () => {
     });
 
     it("should not create a build when there are no files to process", async () => {
-      fileExtractor.setFilesToReturn([]);
+      mockFileExtractor.setFilesToReturn([]);
 
       const handler = new PdfCommandHandler(
         visualSnapshotsApi,
         pdfSnapshotUploaderMock,
-        fileExtractor,
+        mockFileExtractor,
         logger
       );
 
@@ -138,6 +151,12 @@ describe("pdf-handler", () => {
       );
 
       expect(createBuildMock).not.toHaveBeenCalled();
+      expect(mockFileExtractor.calls()).toEqual([
+        {
+          globOrDirs: [path.join(__dirname(import.meta), "../files/1.pdf")],
+          dirGlob: "*.pdf",
+        },
+      ]);
       expect(logged).toEqual([
         { level: 40, msg: "No PDF files found to process." },
       ]);
@@ -146,12 +165,12 @@ describe("pdf-handler", () => {
 
   describe("uploading snapshots", () => {
     it("should call uploadSnapshots with created build ID", async () => {
-      fileExtractor.setFilesToReturn(["/absolute/path/to/files/1.pdf"]);
+      mockFileExtractor.setFilesToReturn(["/absolute/path/to/files/1.pdf"]);
 
       const handler = new PdfCommandHandler(
         visualSnapshotsApi,
         pdfSnapshotUploaderMock,
-        fileExtractor,
+        mockFileExtractor,
         logger
       );
 
@@ -180,12 +199,12 @@ describe("pdf-handler", () => {
     });
 
     it("should call uploadSnapshots with provided build ID", async () => {
-      fileExtractor.setFilesToReturn(["/absolute/path/to/files/1.pdf"]);
+      mockFileExtractor.setFilesToReturn(["/absolute/path/to/files/1.pdf"]);
 
       const handler = new PdfCommandHandler(
         visualSnapshotsApi,
         pdfSnapshotUploaderMock,
-        fileExtractor,
+        mockFileExtractor,
         logger
       );
 
@@ -217,12 +236,12 @@ describe("pdf-handler", () => {
     it("should finish build when buildId is not passed, using created build ID", async () => {
       createBuildMock.mockResolvedValue(buildId);
 
-      fileExtractor.setFilesToReturn(["/absolute/path/to/files/1.pdf"]);
+      mockFileExtractor.setFilesToReturn(["/absolute/path/to/files/1.pdf"]);
 
       const handler = new PdfCommandHandler(
         visualSnapshotsApi,
         pdfSnapshotUploaderMock,
-        fileExtractor,
+        mockFileExtractor,
         logger
       );
 
@@ -242,12 +261,12 @@ describe("pdf-handler", () => {
     });
 
     it("should not finish build when buildId is passed", async () => {
-      fileExtractor.setFilesToReturn(["/absolute/path/to/files/1.pdf"]);
+      mockFileExtractor.setFilesToReturn(["/absolute/path/to/files/1.pdf"]);
 
       const handler = new PdfCommandHandler(
         visualSnapshotsApi,
         pdfSnapshotUploaderMock,
-        fileExtractor,
+        mockFileExtractor,
         logger
       );
 

--- a/visual-js/visual-snapshots/test/app/pdf-handler.spec.ts
+++ b/visual-js/visual-snapshots/test/app/pdf-handler.spec.ts
@@ -4,21 +4,10 @@ import {
   PdfCommandHandler,
   PdfCommandParams,
 } from "../../src/app/pdf-handler.js";
-import { FileExtractor } from "../../src/utils/glob.js";
-import { __dirname, mockLogger } from "../helpers.js";
+import { MockFileExtractor } from "../mock-file-extractor.js";
+import { mockLogger } from "../mock-logger.js";
+import { __dirname } from "../system-helpers.js";
 import path from "path";
-
-class FakeFileExtractor implements FileExtractor {
-  private files: string[] = [];
-
-  public setFilesToReturn(files: string[]) {
-    this.files = files;
-  }
-
-  public async getFiles(_globOrDirs: string[], _dirGlob: string) {
-    return this.files;
-  }
-}
 
 describe("pdf-handler", () => {
   const createBuildMock = jest.fn<
@@ -49,7 +38,7 @@ describe("pdf-handler", () => {
   const snapshotName = "snapshotName";
   const buildId = "buildId";
 
-  const fileExtractor = new FakeFileExtractor();
+  const fileExtractor = new MockFileExtractor();
 
   const { logger, logged, reset: resetLogger } = mockLogger();
 

--- a/visual-js/visual-snapshots/test/app/pdf-handler.spec.ts
+++ b/visual-js/visual-snapshots/test/app/pdf-handler.spec.ts
@@ -81,12 +81,7 @@ describe("pdf-handler", () => {
           dirGlob: "*.pdf",
         },
       ]);
-      expect(logged).toEqual([
-        {
-          level: 30,
-          msg: "Found 2 PDF files to process: /absolute/path/to/files/1.pdf, /absolute/path/to/files/2.pdf",
-        },
-      ]);
+      expect(logged).toMatchSnapshot();
     });
 
     it("should not create a build when buildId is passed", async () => {
@@ -119,12 +114,7 @@ describe("pdf-handler", () => {
           dirGlob: "*.pdf",
         },
       ]);
-      expect(logged).toEqual([
-        {
-          level: 30,
-          msg: "Found 1 PDF file to process: /absolute/path/to/files/1.pdf",
-        },
-      ]);
+      expect(logged).toMatchSnapshot();
     });
 
     it("should not create a build when there are no files to process", async () => {
@@ -157,9 +147,7 @@ describe("pdf-handler", () => {
           dirGlob: "*.pdf",
         },
       ]);
-      expect(logged).toEqual([
-        { level: 40, msg: "No PDF files found to process." },
-      ]);
+      expect(logged).toMatchSnapshot();
     });
   });
 

--- a/visual-js/visual-snapshots/test/mock-file-extractor.ts
+++ b/visual-js/visual-snapshots/test/mock-file-extractor.ts
@@ -2,12 +2,23 @@ import { FileExtractor } from "../src/utils/glob.js";
 
 export class MockFileExtractor implements FileExtractor {
   private files: string[] = [];
+  private calledWith: { globOrDirs: string[]; dirGlob: string }[] = [];
 
   public setFilesToReturn(files: string[]) {
     this.files = files;
   }
 
-  public async getFiles(_globOrDirs: string[], _dirGlob: string) {
+  public async getFiles(globOrDirs: string[], dirGlob: string) {
+    this.calledWith.push({ globOrDirs, dirGlob });
     return this.files;
+  }
+
+  public reset() {
+    this.files = [];
+    this.calledWith = [];
+  }
+
+  public calls() {
+    return this.calledWith;
   }
 }

--- a/visual-js/visual-snapshots/test/mock-file-extractor.ts
+++ b/visual-js/visual-snapshots/test/mock-file-extractor.ts
@@ -1,0 +1,13 @@
+import { FileExtractor } from "../src/utils/glob.js";
+
+export class MockFileExtractor implements FileExtractor {
+  private files: string[] = [];
+
+  public setFilesToReturn(files: string[]) {
+    this.files = files;
+  }
+
+  public async getFiles(_globOrDirs: string[], _dirGlob: string) {
+    return this.files;
+  }
+}

--- a/visual-js/visual-snapshots/test/mock-logger.ts
+++ b/visual-js/visual-snapshots/test/mock-logger.ts
@@ -1,21 +1,5 @@
-import { dirname } from "node:path";
 import { Writable } from "node:stream";
-import { fileURLToPath } from "node:url";
 import { pino } from "pino";
-
-/**
- * ESM helper for getting __filename. Pass `import.meta` to this function.
- * @param meta `import.meta`
- * @returns __filename equivalent
- */
-export const __filename = (meta: ImportMeta) => fileURLToPath(meta.url);
-
-/**
- * ESM helper for getting __dirname. Pass `import.meta` to this function.
- * @param meta `import.meta`
- * @returns __dirname equivalent
- */
-export const __dirname = (meta: ImportMeta) => dirname(__filename(meta));
 
 export function mockLogger() {
   const logged: object[] = [];

--- a/visual-js/visual-snapshots/test/system-helpers.ts
+++ b/visual-js/visual-snapshots/test/system-helpers.ts
@@ -1,0 +1,16 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * ESM helper for getting __filename. Pass `import.meta` to this function.
+ * @param meta `import.meta`
+ * @returns __filename equivalent
+ */
+export const __filename = (meta: ImportMeta) => fileURLToPath(meta.url);
+
+/**
+ * ESM helper for getting __dirname. Pass `import.meta` to this function.
+ * @param meta `import.meta`
+ * @returns __dirname equivalent
+ */
+export const __dirname = (meta: ImportMeta) => dirname(__filename(meta));

--- a/visual-js/visual-snapshots/test/utils/glob.spec.ts
+++ b/visual-js/visual-snapshots/test/utils/glob.spec.ts
@@ -1,6 +1,8 @@
-import { getFiles } from "../../src/utils/glob.js";
+import { GlobFileExtractor } from "../../src/utils/glob.js";
 import path from "path";
 import { __dirname, __filename } from "../helpers.js";
+
+const glob = new GlobFileExtractor();
 
 describe("getFiles", () => {
   function normalize(paths: string[]) {
@@ -11,7 +13,7 @@ describe("getFiles", () => {
     const input = ["./src/index.ts"];
     const expected = normalize(input);
 
-    const result = await getFiles(input, "*");
+    const result = await glob.getFiles(input, "*");
     expect(normalize(result)).toEqual(expected);
   });
 
@@ -19,7 +21,7 @@ describe("getFiles", () => {
     const input = ["./src/index.ts", __filename(import.meta)];
     const expected = normalize(input);
 
-    const actual = await getFiles(input, "*");
+    const actual = await glob.getFiles(input, "*");
     expect(normalize(actual)).toEqual(expected);
   });
 
@@ -27,7 +29,7 @@ describe("getFiles", () => {
     const input = [path.join(__dirname(import.meta), "*.spec.ts")];
     const expected = normalize([__filename(import.meta)]);
 
-    const actual = await getFiles(input, "*");
+    const actual = await glob.getFiles(input, "*");
     expect(normalize(actual)).toEqual(expect.arrayContaining(expected));
   });
 
@@ -35,7 +37,7 @@ describe("getFiles", () => {
     const input = [__dirname(import.meta)];
     const expected = normalize([__filename(import.meta)]);
 
-    const actual = await getFiles(input, "*.spec.ts");
+    const actual = await glob.getFiles(input, "*.spec.ts");
     expect(normalize(actual)).toEqual(expect.arrayContaining(expected));
   });
 
@@ -46,7 +48,7 @@ describe("getFiles", () => {
     ];
     const expected = normalize([__filename(import.meta)]);
 
-    const result = await getFiles(input, "*");
+    const result = await glob.getFiles(input, "*");
     expect(normalize(result)).toEqual(expected);
   });
 
@@ -54,7 +56,7 @@ describe("getFiles", () => {
     const input = [__dirname(import.meta) + ".not-existing"];
     const expected: string[] = [];
 
-    const result = await getFiles(input, "*");
+    const result = await glob.getFiles(input, "*");
     expect(normalize(result)).toEqual(expected);
   });
 });

--- a/visual-js/visual-snapshots/test/utils/glob.spec.ts
+++ b/visual-js/visual-snapshots/test/utils/glob.spec.ts
@@ -1,6 +1,6 @@
 import { GlobFileExtractor } from "../../src/utils/glob.js";
 import path from "path";
-import { __dirname, __filename } from "../helpers.js";
+import { __dirname, __filename } from "../system-helpers.js";
 
 const glob = new GlobFileExtractor();
 

--- a/visual-js/visual-snapshots/test/utils/pool.spec.ts
+++ b/visual-js/visual-snapshots/test/utils/pool.spec.ts
@@ -1,7 +1,7 @@
 import workerpool, { WorkerPoolOptions } from "workerpool";
 import path from "path";
 import { execAll, WorkerMethod } from "../../src/utils/pool.js";
-import { __dirname } from "../helpers.js";
+import { __dirname } from "../system-helpers.js";
 
 function* workers(
   elements: number[]

--- a/visual-js/visual-snapshots/test/utils/templates.spec.ts
+++ b/visual-js/visual-snapshots/test/utils/templates.spec.ts
@@ -38,7 +38,7 @@ describe("buildFileMetadata", () => {
     ).toEqual(expected);
   });
 
-  it("build file metadata for a file ourside the current directory ", () => {
+  it("build file metadata for a file outside the current directory ", () => {
     const expected = {
       filename: "test2",
       ext: ".pdf",
@@ -52,6 +52,19 @@ describe("buildFileMetadata", () => {
         1,
         "/absolute/path/current-dir"
       )
+    ).toEqual(expected);
+  });
+
+  it("build file metadata for file in the home directory", () => {
+    const expected = {
+      filename: "test1",
+      ext: ".pdf",
+      directory: "",
+      directoryRelative: "../../..",
+      page: 3,
+    };
+    expect(
+      buildFileMetadata("/test1.pdf", 3, "/absolute/path/current-dir")
     ).toEqual(expected);
   });
 });


### PR DESCRIPTION
- Do not create a build when there are no files to process
- Log files to be processed
- Extra test
- Divide test helpers into files
- Add tests which check that we only look for pdf files 