### PR TITLE
[Java] Add local selenium grid support for basic snapshots

### DIFF
--- a/visual-java/pom.xml
+++ b/visual-java/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
-      <version>4.10.0</version>
+      <version>4.32.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/visual-java/pom.xml
+++ b/visual-java/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
-      <version>4.32.0</version>
+      <version>4.10.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/visual-java/src/main/java/com/saucelabs/visual/VisualApi.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/VisualApi.java
@@ -11,23 +11,30 @@ import com.saucelabs.visual.model.DiffingMethodTolerance;
 import com.saucelabs.visual.model.FullPageScreenshotConfig;
 import com.saucelabs.visual.model.IgnoreRegion;
 import com.saucelabs.visual.model.VisualRegion;
+import com.saucelabs.visual.utils.CapabilityUtils;
 import com.saucelabs.visual.utils.ConsoleColors;
 import com.saucelabs.visual.utils.EnvironmentVariables;
 import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
+import java.lang.reflect.Field;
+import java.net.URL;
 import java.time.Duration;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.http.client.config.RequestConfig;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.remote.RemoteWebDriver;
-import org.openqa.selenium.remote.RemoteWebElement;
+import org.openqa.selenium.remote.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class VisualApi {
   private static final Logger log = LoggerFactory.getLogger(VisualApi.class);
+  private static final Pattern sauceRegionRegex = Pattern.compile("saucelabs.(com|net)");
 
   private static String resolveEndpoint() {
     return DataCenter.fromSauceRegion(EnvironmentVariables.SAUCE_REGION).endpoint;
@@ -49,6 +56,7 @@ public class VisualApi {
     private DiffingMethodSensitivity diffingMethodSensitivity;
     private DiffingMethodTolerance diffingMethodTolerance;
     private RequestConfig requestConfig;
+    private Boolean isSauceSession;
 
     public Builder(RemoteWebDriver driver, String username, String accessKey) {
       this(driver, username, accessKey, resolveEndpoint());
@@ -115,15 +123,22 @@ public class VisualApi {
       return this;
     }
 
+    /**
+     * Set whether this is running against a Sauce session. If not called, we'll do our best to
+     * automatically determine this setting. Set false to run against a local grid / local Selenium
+     * session.
+     */
+    public Builder withSauceSession(Boolean isSauceSession) {
+      this.isSauceSession = isSauceSession;
+      return this;
+    }
+
+    private BuildAttributes getBuildAttributes() {
+      return new BuildAttributes(buildName, projectName, branchName, defaultBranchName);
+    }
+
     public VisualApi build() {
-      VisualApi api =
-          new VisualApi(
-              driver,
-              endpoint,
-              username,
-              accessKey,
-              new BuildAttributes(buildName, projectName, branchName, defaultBranchName),
-              requestConfig);
+      VisualApi api = new VisualApi(this);
 
       if (this.captureDom != null) {
         api.setCaptureDom(this.captureDom);
@@ -157,6 +172,7 @@ public class VisualApi {
   private DiffingMethodTolerance diffingMethodTolerance;
   private String sessionMetadataBlob;
   private final RemoteWebDriver driver;
+  private Boolean isSauceSession;
 
   /**
    * Creates a VisualApi instance for a given Visual Backend {@link DataCenter}
@@ -230,6 +246,17 @@ public class VisualApi {
       String accessKey,
       BuildAttributes buildAttributes,
       RequestConfig requestConfig) {
+    this(driver, url, username, accessKey, buildAttributes, requestConfig, false);
+  }
+
+  private VisualApi(
+      RemoteWebDriver driver,
+      String url,
+      String username,
+      String accessKey,
+      BuildAttributes buildAttributes,
+      RequestConfig requestConfig,
+      Boolean isSauceSession) {
     if (username == null
         || accessKey == null
         || username.trim().isEmpty()
@@ -243,8 +270,20 @@ public class VisualApi {
     String jobIdString = (String) driver.getCapabilities().getCapability("jobUuid");
     this.jobId = jobIdString == null ? sessionId : jobIdString;
     this.build = VisualBuild.getBuildOnce(this, buildAttributes);
-    this.sessionMetadataBlob = this.webdriverSessionInfo().blob;
     this.driver = driver;
+    this.isSauceSession = isSauceSession;
+    refreshWebDriverSessionInfo();
+  }
+
+  private VisualApi(Builder builder) {
+    this(
+        builder.driver,
+        builder.endpoint,
+        builder.username,
+        builder.accessKey,
+        builder.getBuildAttributes(),
+        builder.requestConfig,
+        builder.isSauceSession);
   }
 
   VisualApi(
@@ -281,6 +320,41 @@ public class VisualApi {
     this.driver = driver;
     this.client = new GraphQLClient(url, username, accessKey, requestConfig);
     this.sessionMetadataBlob = sessionMetadataBlob;
+  }
+
+  /**
+   * Use reflection to attempt to automatically determine if the current session is Sauce if not
+   * already configured by the user or cached.
+   */
+  private boolean isSauceSession() {
+    if (isSauceSession != null) {
+      return isSauceSession;
+    }
+
+    CommandExecutor executor = this.driver.getCommandExecutor();
+    Object resolvedExecutor = null;
+    if (executor instanceof TracedCommandExecutor) {
+      try {
+        final Field field = TracedCommandExecutor.class.getDeclaredField("delegate");
+        field.setAccessible(true);
+        resolvedExecutor = field.get(executor);
+      } catch (NoSuchFieldException | IllegalAccessException ignored) {
+      }
+    } else if (executor instanceof HttpCommandExecutor) {
+      resolvedExecutor = executor;
+    }
+
+    if (resolvedExecutor instanceof HttpCommandExecutor) {
+      URL remoteUrl = ((HttpCommandExecutor) resolvedExecutor).getAddressOfRemoteServer();
+      Matcher matcher = sauceRegionRegex.matcher(remoteUrl.toString());
+      isSauceSession = matcher.find();
+    } else {
+      // Fallback to assuming this is currently a sauce session. This can be overridden via the
+      // builder options.
+      isSauceSession = true;
+    }
+
+    return isSauceSession;
   }
 
   /**
@@ -323,14 +397,14 @@ public class VisualApi {
     this.diffingMethodTolerance = diffingMethodTolerance;
   }
 
-  private WebdriverSessionInfoQuery.Result webdriverSessionInfo() {
+  private String webdriverSessionInfo() {
     WebdriverSessionInfoQuery query =
         new WebdriverSessionInfoQuery(
             new WebdriverSessionInfoQuery.WebdriverSessionInfoIn(this.jobId, this.sessionId));
     try {
       WebdriverSessionInfoQuery.Data response =
           this.client.execute(query, WebdriverSessionInfoQuery.Data.class);
-      return response.result;
+      return response.result.blob;
     } catch (VisualApiException e) {
       log.error(
           "Sauce Visual: No WebDriver session found. Please make sure WebDriver and Sauce Visual data centers are aligned.");
@@ -466,6 +540,14 @@ public class VisualApi {
    * @param options Options for the API
    */
   public void sauceVisualCheck(String snapshotName, CheckOptions options) {
+    if (isSauceSession()) {
+      sauceVisualCheckSauce(snapshotName, options);
+    } else {
+      sauceVisualCheckLocal(snapshotName, options);
+    }
+  }
+
+  private void sauceVisualCheckSauce(String snapshotName, CheckOptions options) {
     DiffingMethod diffingMethod = toDiffingMethod(options);
 
     CreateSnapshotFromWebDriverMutation.CreateSnapshotFromWebDriverIn input =
@@ -517,16 +599,12 @@ public class VisualApi {
       input.setHideScrollBars(hideScrollBars);
     }
 
-    DiffingMethodSensitivity diffingMethodSensitivity =
-        Optional.ofNullable(options.getDiffingMethodSensitivity())
-            .orElse(this.diffingMethodSensitivity);
+    DiffingMethodSensitivity diffingMethodSensitivity = getDiffingMethodSensitivity(options);
     if (diffingMethodSensitivity != null) {
       input.setDiffingMethodSensitivity(diffingMethodSensitivity);
     }
 
-    DiffingMethodTolerance diffingMethodTolerance =
-        Optional.ofNullable(options.getDiffingMethodTolerance())
-            .orElse(this.diffingMethodTolerance);
+    DiffingMethodTolerance diffingMethodTolerance = getDiffingMethodTolerance(options);
     if (diffingMethodTolerance != null) {
       input.setDiffingMethodTolerance(diffingMethodTolerance);
     }
@@ -538,6 +616,57 @@ public class VisualApi {
       uploadedDiffIds.addAll(
           check.result.diffs.getNodes().stream().map(Diff::getId).collect(Collectors.toList()));
     }
+  }
+
+  private void sauceVisualCheckLocal(String snapshotName, CheckOptions checkOptions) {
+    byte[] screenshot = driver.getScreenshotAs(OutputType.BYTES);
+
+    // create upload and get urls
+    CreateSnapshotUploadMutation mutation =
+        new CreateSnapshotUploadMutation(
+            SnapshotUploadIn.builder().withBuildId(this.build.getId()).build());
+    SnapshotUpload uploadResult =
+        this.client.execute(mutation, CreateSnapshotUploadMutation.Data.class).result;
+
+    // upload image
+    this.client.upload(uploadResult.getImageUploadUrl(), screenshot);
+    Capabilities caps = driver.getCapabilities();
+
+    // create snapshot using upload id
+    CreateSnapshotMutation snapshotMutation =
+        new CreateSnapshotMutation(
+            SnapshotIn.builder()
+                .withBrowser(CapabilityUtils.getBrowser(caps))
+                .withBrowserVersion(caps.getBrowserVersion())
+                .withOperatingSystem(CapabilityUtils.getOperatingSystem(caps))
+                .withUploadId(uploadResult.getId())
+                .withBuildId(this.build.getId())
+                .withTestName(checkOptions.getTestName())
+                .withSuiteName(checkOptions.getSuiteName())
+                .withDiffingMethod(toDiffingMethod(checkOptions))
+                .withDiffingOptions(checkOptions.getDiffingOptions())
+                .withIgnoreRegions(extractIgnoreList(checkOptions))
+                .withDiffingMethodSensitivity(
+                    Optional.ofNullable(getDiffingMethodSensitivity(checkOptions))
+                        .map(DiffingMethodSensitivity::asGraphQLType)
+                        .orElse(null))
+                .withDiffingMethodTolerance(
+                    Optional.ofNullable(getDiffingMethodTolerance(checkOptions))
+                        .map(DiffingMethodTolerance::asGraphQLType)
+                        .orElse(null))
+                .withName(snapshotName)
+                .build());
+    this.client.execute(snapshotMutation, CreateSnapshotMutation.Data.class);
+  }
+
+  private DiffingMethodSensitivity getDiffingMethodSensitivity(CheckOptions checkOptions) {
+    DiffingMethodSensitivity sensitivity = checkOptions.getDiffingMethodSensitivity();
+    return sensitivity != null ? sensitivity : this.diffingMethodSensitivity;
+  }
+
+  private DiffingMethodTolerance getDiffingMethodTolerance(CheckOptions checkOptions) {
+    DiffingMethodTolerance sensitivity = checkOptions.getDiffingMethodTolerance();
+    return sensitivity != null ? sensitivity : this.diffingMethodTolerance;
   }
 
   private static DiffingMethod toDiffingMethod(CheckOptions options) {
@@ -610,7 +739,9 @@ public class VisualApi {
   }
 
   public void refreshWebDriverSessionInfo() {
-    this.sessionMetadataBlob = this.webdriverSessionInfo().blob;
+    if (isSauceSession()) {
+      this.sessionMetadataBlob = this.webdriverSessionInfo();
+    }
   }
 
   private List<RegionIn> extractIgnoreList(CheckOptions options) {

--- a/visual-java/src/main/java/com/saucelabs/visual/VisualApi.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/VisualApi.java
@@ -658,9 +658,7 @@ public class VisualApi {
     this.client.execute(snapshotMutation, CreateSnapshotMutation.Data.class);
   }
 
-  /**
-   * Parse the Selenium parsed value from window.devicePixelRatio into a Double for our API
-   */
+  /** Parse the Selenium parsed value from window.devicePixelRatio into a Double for our API */
   private double formatDevicePixelRatio(Object rawDpr) {
     double dpr = 1.0;
 

--- a/visual-java/src/main/java/com/saucelabs/visual/graphql/CreateSnapshotMutation.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/graphql/CreateSnapshotMutation.java
@@ -1,0 +1,33 @@
+package com.saucelabs.visual.graphql;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.saucelabs.visual.graphql.type.Snapshot;
+import com.saucelabs.visual.graphql.type.SnapshotIn;
+import java.util.Collections;
+import java.util.Map;
+
+public class CreateSnapshotMutation implements GraphQLOperation {
+  SnapshotIn input;
+
+  @Override
+  public String getQuery() {
+    return "mutation createSnapshot($input: SnapshotIn!) { result: createSnapshot(input: $input) { __typename id } }";
+  }
+
+  public CreateSnapshotMutation(SnapshotIn snapshotIn) {
+    this.input = snapshotIn;
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return Collections.singletonMap("input", input);
+  }
+
+  public static class Data {
+    public final Snapshot result;
+
+    public Data(@JsonProperty("result") Snapshot result) {
+      this.result = result;
+    }
+  }
+}

--- a/visual-java/src/main/java/com/saucelabs/visual/graphql/CreateSnapshotUploadMutation.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/graphql/CreateSnapshotUploadMutation.java
@@ -1,0 +1,33 @@
+package com.saucelabs.visual.graphql;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.saucelabs.visual.graphql.type.SnapshotUpload;
+import com.saucelabs.visual.graphql.type.SnapshotUploadIn;
+import java.util.Collections;
+import java.util.Map;
+
+public class CreateSnapshotUploadMutation implements GraphQLOperation {
+  SnapshotUploadIn input;
+
+  @Override
+  public String getQuery() {
+    return "mutation createSnapshotUpload($input: SnapshotUploadIn!) { result: createSnapshotUpload(input: $input) { id buildId imageUploadUrl domUploadUrl } }";
+  }
+
+  public CreateSnapshotUploadMutation(SnapshotUploadIn snapshotUploadIn) {
+    this.input = snapshotUploadIn;
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return Collections.singletonMap("input", input);
+  }
+
+  public static class Data {
+    public final SnapshotUpload result;
+
+    public Data(@JsonProperty("result") SnapshotUpload result) {
+      this.result = result;
+    }
+  }
+}

--- a/visual-java/src/main/java/com/saucelabs/visual/graphql/GraphQLClient.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/graphql/GraphQLClient.java
@@ -14,6 +14,8 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
@@ -59,6 +61,26 @@ public class GraphQLClient {
     }
 
     this.objectMapper = objectMapper;
+  }
+
+  /**
+   * Uploads an image/png file to Sauce's visual storage.
+   *
+   * @param uri The URL retrieved from the createSnapshotUpload mutation.
+   * @param image An image byte array, retrieved from the selenium driver's getScreenshotAs()
+   *     method.
+   */
+  public void upload(String uri, byte[] image) throws VisualApiException {
+    HttpPut request = new HttpPut(uri);
+    request.setHeader(HttpHeaders.CONTENT_TYPE, "image/png");
+    request.setConfig(requestConfig);
+    request.setEntity(new ByteArrayEntity(image));
+
+    try {
+      client.execute(request);
+    } catch (IOException e) {
+      throw new VisualApiException(e.getMessage(), e);
+    }
   }
 
   public <D> D execute(GraphQLOperation operation, Class<D> responseType)

--- a/visual-java/src/main/java/com/saucelabs/visual/utils/CapabilityUtils.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/utils/CapabilityUtils.java
@@ -1,0 +1,44 @@
+package com.saucelabs.visual.utils;
+
+import com.saucelabs.visual.graphql.type.Browser;
+import com.saucelabs.visual.graphql.type.OperatingSystem;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.Platform;
+
+public class CapabilityUtils {
+  public static Browser getBrowser(Capabilities caps) {
+    switch (caps.getBrowserName()) {
+      case "chrome":
+        return Browser.CHROME;
+      case "edge":
+        return Browser.EDGE;
+      case "firefox":
+        return Browser.FIREFOX;
+      case "safari":
+        return Browser.SAFARI;
+      default:
+        return Browser.NONE;
+    }
+  }
+
+  public static OperatingSystem getOperatingSystem(Capabilities caps) {
+    Platform platform = caps.getPlatformName();
+    Platform family = platform.family();
+    // Android / iOS have null families, so return the family (Windows) if it exists,
+    // otherwise use the platform name as a fallback
+    switch (family != null ? family : platform) {
+      case MAC:
+        return OperatingSystem.MACOS;
+      case UNIX:
+        return OperatingSystem.LINUX;
+      case WINDOWS:
+        return OperatingSystem.WINDOWS;
+      case ANDROID:
+        return OperatingSystem.ANDROID;
+      case IOS:
+        return OperatingSystem.IOS;
+      default:
+        return OperatingSystem.UNKNOWN;
+    }
+  }
+}


### PR DESCRIPTION
## Description
Adds local selenium grid support to our Java SDK. This should automatically determine if this is a sauce session (In most instances) and either run our capture tooling from our backend or the simplified solution from our SDK directly using Selenium APIs.

Currently this omits the following:

- Full page screenshot support
- Element based ignore regions
- element / page clipping
- dom capture (and therefore selective diffing)

## Types of Changes

- New feature (non-breaking change which adds functionality)
