### PR TITLE
[no-ticket] visual-java: fix invalid check for options.getRegions

### DIFF
--- a/visual-java/src/main/java/com/saucelabs/visual/VisualApi.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/VisualApi.java
@@ -785,7 +785,7 @@ public class VisualApi {
         options.getIgnoreRegions() == null ? Arrays.asList() : options.getIgnoreRegions();
 
     List<VisualRegion> visualRegions =
-        options.getIgnoreRegions() == null ? Arrays.asList() : options.getRegions();
+        options.getRegions() == null ? Arrays.asList() : options.getRegions();
 
     List<RegionIn> result = new ArrayList<>();
     for (int i = 0; i < ignoredRegions.size(); i++) {


### PR DESCRIPTION
# visual-java: fix invalid check for `options.getRegions`

## Description
`getIgnoreRegions()` is checked against `null` instead of `getRegions()` when retrieving regions.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
