### PR TITLE
[INT-282] visual-java: retrieve data from browser in bulk when possible

### DIFF
--- a/visual-java/src/main/java/com/saucelabs/visual/VisualApi.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/VisualApi.java
@@ -787,21 +787,6 @@ public class VisualApi {
     return null;
   }
 
-  private WebElement getElement(IgnoreSelectorIn ignoreSelector) {
-    SelectorIn selector = ignoreSelector.getSelector();
-    By bySelector;
-
-    switch (selector.getType()) {
-      case XPATH:
-        bySelector = By.xpath(selector.getValue());
-        break;
-      default:
-        return null;
-    }
-
-    return driver.findElement(bySelector);
-  }
-
   private static DiffingMethod toDiffingMethod(CheckOptions options) {
     if (options == null || options.getDiffingMethod() == null) {
       return DiffingMethod.BALANCED;
@@ -984,13 +969,15 @@ public class VisualApi {
             ? options.getIgnoreSelectors()
             : Arrays.asList();
 
-    List<WebElement> elements = new ArrayList<>();
-    for (IgnoreSelectorIn ignoreSelector : selectors) {
-      WebElement element = getElement(ignoreSelector);
+    List<WebElement> elements =
+        bulkDriverHelper.resolveElements(
+            selectors.stream().map(IgnoreSelectorIn::getSelector).collect(Collectors.toList()));
+    for (int i = 0; i < selectors.size(); i++) {
+      WebElement element = elements.get(i);
+      IgnoreSelectorIn selector = selectors.get(i);
       if (element == null) {
-        throw new InvalidIgnoreSelectorException(ignoreSelector, "Web element does not exist");
+        throw new InvalidIgnoreSelectorException(selector, "Web element does not exist");
       }
-      elements.add(element);
     }
 
     List<RegionIn> regions = extractElementsToIgnoreRegions(elements);

--- a/visual-java/src/main/java/com/saucelabs/visual/VisualApi.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/VisualApi.java
@@ -903,8 +903,7 @@ public class VisualApi {
       }
     }
 
-    List<Boolean> bulkIsDisplayed = bulkDriverHelper.getIsDisplayed(bulkWebElements);
-
+    List<Boolean> bulkIsDisplayed = bulkDriverHelper.areDisplayed(bulkWebElements);
     for (int i = 0; i < bulkIsDisplayed.size(); i++) {
       VisualRegion region = bulkRegions.get(i);
       Boolean isDisplayed = bulkIsDisplayed.get(i);
@@ -930,7 +929,8 @@ public class VisualApi {
             : Arrays.asList();
 
     List<ElementIn> result = new ArrayList<>();
-    List<Boolean> bulkIsDisplayed = bulkDriverHelper.getIsDisplayed(ignoredElements);
+
+    List<Boolean> bulkIsDisplayed = bulkDriverHelper.areDisplayed(ignoredElements);
     for (int i = 0; i < bulkIsDisplayed.size(); i++) {
       WebElement element = ignoredElements.get(i);
       Boolean isDisplayed = bulkIsDisplayed.get(i);
@@ -946,7 +946,8 @@ public class VisualApi {
 
   private List<RegionIn> extractElementsToIgnoreRegions(List<WebElement> elements) {
     List<RegionIn> result = new ArrayList<>();
-    List<Boolean> bulkIsDisplayed = bulkDriverHelper.getIsDisplayed(elements);
+
+    List<Boolean> bulkIsDisplayed = bulkDriverHelper.areDisplayed(elements);
     for (int i = 0; i < bulkIsDisplayed.size(); i++) {
       WebElement element = elements.get(i);
       Boolean isDisplayed = bulkIsDisplayed.get(i);
@@ -980,8 +981,9 @@ public class VisualApi {
       }
     }
 
-    List<RegionIn> regions = extractElementsToIgnoreRegions(elements);
     List<RegionIn> result = new ArrayList<>();
+
+    List<RegionIn> regions = extractElementsToIgnoreRegions(elements);
     for (int i = 0; i < regions.size(); i++) {
       IgnoreSelectorIn selector = selectors.get(i);
       RegionIn region = regions.get(i);

--- a/visual-java/src/main/java/com/saucelabs/visual/VisualApi.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/VisualApi.java
@@ -908,7 +908,8 @@ public class VisualApi {
       VisualRegion region = bulkRegions.get(i);
       Boolean isDisplayed = bulkIsDisplayed.get(i);
       if (!isDisplayed) {
-        throw new InvalidVisualRegionException(region, "Visual region's web element does not exist (yet)");
+        throw new InvalidVisualRegionException(
+            region, "Visual region's web element does not exist (yet)");
       }
     }
 

--- a/visual-java/src/main/java/com/saucelabs/visual/VisualApi.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/VisualApi.java
@@ -909,7 +909,7 @@ public class VisualApi {
       VisualRegion region = bulkRegions.get(i);
       Boolean isDisplayed = bulkIsDisplayed.get(i);
       if (!isDisplayed) {
-        throw new InvalidVisualRegionException(region, "Visual region's WebElement is not visible");
+        throw new InvalidVisualRegionException(region, "Visual region's web element does not exist (yet)");
       }
     }
 

--- a/visual-java/src/main/java/com/saucelabs/visual/exception/InvalidIgnoreSelectorException.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/exception/InvalidIgnoreSelectorException.java
@@ -1,0 +1,16 @@
+package com.saucelabs.visual.exception;
+
+import com.saucelabs.visual.graphql.type.IgnoreSelectorIn;
+
+public class InvalidIgnoreSelectorException extends VisualApiException {
+  private final IgnoreSelectorIn ignoreSelectorIn;
+
+  public InvalidIgnoreSelectorException(IgnoreSelectorIn selector, String message) {
+    super(message);
+    this.ignoreSelectorIn = selector;
+  }
+
+  public IgnoreSelectorIn getIgnoreSelectorIn() {
+    return ignoreSelectorIn;
+  }
+}

--- a/visual-java/src/main/java/com/saucelabs/visual/exception/InvalidSelectorException.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/exception/InvalidSelectorException.java
@@ -1,0 +1,16 @@
+package com.saucelabs.visual.exception;
+
+import com.saucelabs.visual.graphql.type.SelectorIn;
+
+public class InvalidSelectorException extends VisualApiException {
+  private final SelectorIn selectorIn;
+
+  public InvalidSelectorException(SelectorIn selector, String message) {
+    super(message);
+    this.selectorIn = selector;
+  }
+
+  public SelectorIn getSelectorIn() {
+    return selectorIn;
+  }
+}

--- a/visual-java/src/main/java/com/saucelabs/visual/exception/InvalidVisualRegionException.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/exception/InvalidVisualRegionException.java
@@ -1,0 +1,16 @@
+package com.saucelabs.visual.exception;
+
+import com.saucelabs.visual.model.VisualRegion;
+
+public class InvalidVisualRegionException extends VisualApiException {
+  private final VisualRegion visualRegion;
+
+  public InvalidVisualRegionException(VisualRegion visualRegion, String message) {
+    super(message);
+    this.visualRegion = visualRegion;
+  }
+
+  public VisualRegion getVisualRegion() {
+    return visualRegion;
+  }
+}

--- a/visual-java/src/main/java/com/saucelabs/visual/exception/InvalidWebElementException.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/exception/InvalidWebElementException.java
@@ -1,0 +1,16 @@
+package com.saucelabs.visual.exception;
+
+import org.openqa.selenium.WebElement;
+
+public class InvalidWebElementException extends VisualApiException {
+  private final WebElement webElement;
+
+  public InvalidWebElementException(WebElement webElement, String message) {
+    super(message);
+    this.webElement = webElement;
+  }
+
+  public WebElement getWebElement() {
+    return webElement;
+  }
+}

--- a/visual-java/src/main/java/com/saucelabs/visual/model/VisualRegion.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/model/VisualRegion.java
@@ -30,6 +30,16 @@ public class VisualRegion {
     this.y = ir.getY();
   }
 
+  public VisualRegion(IgnoreRegion ir, DiffingOptionsIn diffingOptions) {
+    this.options = diffingOptions;
+    this.isIgnoreRegion = true;
+    this.name = ir.getName();
+    this.height = ir.getHeight();
+    this.width = ir.getWidth();
+    this.x = ir.getX();
+    this.y = ir.getY();
+  }
+
   public VisualRegion(WebElement element, DiffingOptionsIn diffingOptions) {
     this.options = diffingOptions;
     this.element = element;
@@ -67,6 +77,16 @@ public class VisualRegion {
     return VisualRegion.ignoreChangesFor("", x, y, width, height);
   }
 
+  public static VisualRegion ignoreChangesFor(String name, Rectangle rectangle) {
+    return VisualRegion.ignoreChangesFor(
+        name, rectangle.x, rectangle.y, rectangle.width, rectangle.height);
+  }
+
+  public static VisualRegion ignoreChangesFor(Rectangle rectangle) {
+    return VisualRegion.ignoreChangesFor(
+        "", rectangle.x, rectangle.y, rectangle.width, rectangle.height);
+  }
+
   public static VisualRegion detectChangesFor(String name, int x, int y, int width, int height) {
     VisualRegion r = new VisualRegion();
     r.options = setAllFlags(new DiffingOptionsIn(), true);
@@ -81,6 +101,11 @@ public class VisualRegion {
 
   public static VisualRegion detectChangesFor(int x, int y, int width, int height) {
     return VisualRegion.detectChangesFor("", x, y, width, height);
+  }
+
+  public static VisualRegion detectChangesFor(String name, Rectangle rectangle) {
+    return VisualRegion.detectChangesFor(
+        name, rectangle.x, rectangle.y, rectangle.width, rectangle.height);
   }
 
   private static DiffingOptionsIn setAllFlags(DiffingOptionsIn opt, boolean value) {

--- a/visual-java/src/main/java/com/saucelabs/visual/model/VisualRegion.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/model/VisualRegion.java
@@ -108,6 +108,11 @@ public class VisualRegion {
         name, rectangle.x, rectangle.y, rectangle.width, rectangle.height);
   }
 
+  public static VisualRegion detectChangesFor(Rectangle rectangle) {
+    return VisualRegion.detectChangesFor(
+        "", rectangle.x, rectangle.y, rectangle.width, rectangle.height);
+  }
+
   private static DiffingOptionsIn setAllFlags(DiffingOptionsIn opt, boolean value) {
     opt.setContent(value);
     opt.setDimensions(value);

--- a/visual-java/src/main/java/com/saucelabs/visual/utils/BulkDriverHelper.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/utils/BulkDriverHelper.java
@@ -43,7 +43,7 @@ public class BulkDriverHelper {
     return result;
   }
 
-  public List<Boolean> getIsDisplayed(List<WebElement> elements) {
+  public List<Boolean> areDisplayed(List<WebElement> elements) {
     final String script =
         "return Array.from(arguments[0]).map(function (element) {"
             + "  if (!element) throw new Error('element cannot be null');"

--- a/visual-java/src/main/java/com/saucelabs/visual/utils/BulkDriverHelper.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/utils/BulkDriverHelper.java
@@ -53,12 +53,17 @@ public class BulkDriverHelper {
     return (List<Boolean>) driver.executeScript(script, elements);
   }
 
-  public List<WebElement> resolveElements(List<SelectorIn> selectors) {
+  public List<List<WebElement>> resolveElements(List<SelectorIn> selectors) {
     final String script =
         "return Array.from(arguments[0]).map(function (xpath) {"
-            + "  return document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)"
-            + "    .singleNodeValue"
-            + "});";
+            + "  var it = document.evaluate(xpath, document, null, XPathResult.UNORDERED_NODE_ITERATOR_TYPE, null);"
+            + "  var result = [];"
+            + "  var element;"
+            + "  while (element = it.iterateNext()) {"
+            + "    result.push(element);"
+            + "  };"
+            + "  return result;"
+            + "})";
 
     List<String> xpaths = new ArrayList<>();
 
@@ -72,6 +77,6 @@ public class BulkDriverHelper {
       }
     }
 
-    return (List<WebElement>) driver.executeScript(script, xpaths);
+    return (List<List<WebElement>>) driver.executeScript(script, xpaths);
   }
 }

--- a/visual-java/src/main/java/com/saucelabs/visual/utils/BulkDriverHelper.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/utils/BulkDriverHelper.java
@@ -1,0 +1,55 @@
+package com.saucelabs.visual.utils;
+
+import java.util.*;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.Rectangle;
+import org.openqa.selenium.WebElement;
+
+public class BulkDriverHelper {
+  private final JavascriptExecutor driver;
+
+  public BulkDriverHelper(JavascriptExecutor javascriptExecutor) {
+    this.driver = javascriptExecutor;
+  }
+
+  public List<Rectangle> getRects(List<WebElement> elements) {
+    final String script =
+        "return Array.from(arguments[0]).map(function (element) {"
+            + "  if (!element) throw new Error('element cannot be null');"
+            + "  const rect = element.getBoundingClientRect();"
+            + "  return {"
+            + "    width: Math.round(rect.width),"
+            + "    height: Math.round(rect.height),"
+            + "    x: Math.round(rect.x + this.window.scrollX),"
+            + "    y: Math.round(rect.y + this.window.scrollY)"
+            + "  };"
+            + "});";
+
+    List<Map<String, Long>> jsResult =
+        (List<Map<String, Long>>) driver.executeScript(script, elements);
+    List<Rectangle> result = new ArrayList<>();
+
+    for (int i = 0; i < elements.size(); i++) {
+      Map<String, Long> jsRect = jsResult.get(i);
+
+      int width = jsRect.get("width").intValue();
+      int height = jsRect.get("height").intValue();
+      int x = jsRect.get("x").intValue();
+      int y = jsRect.get("y").intValue();
+
+      result.add(new Rectangle(x, y, height, width));
+    }
+
+    return result;
+  }
+
+  public List<Boolean> getIsDisplayed(List<WebElement> elements) {
+    final String script =
+        "return Array.from(arguments[0]).map(function (element) {"
+            + "  if (!element) throw new Error('element cannot be null');"
+            + "  return element.checkVisibility();"
+            + "});";
+
+    return (List<Boolean>) driver.executeScript(script, elements);
+  }
+}

--- a/visual-java/src/main/java/com/saucelabs/visual/utils/BulkDriverHelper.java
+++ b/visual-java/src/main/java/com/saucelabs/visual/utils/BulkDriverHelper.java
@@ -1,9 +1,9 @@
 package com.saucelabs.visual.utils;
 
+import com.saucelabs.visual.exception.InvalidSelectorException;
+import com.saucelabs.visual.graphql.type.SelectorIn;
 import java.util.*;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.Rectangle;
-import org.openqa.selenium.WebElement;
+import org.openqa.selenium.*;
 
 public class BulkDriverHelper {
   private final JavascriptExecutor driver;
@@ -51,5 +51,27 @@ public class BulkDriverHelper {
             + "});";
 
     return (List<Boolean>) driver.executeScript(script, elements);
+  }
+
+  public List<WebElement> resolveElements(List<SelectorIn> selectors) {
+    final String script =
+        "return Array.from(arguments[0]).map(function (xpath) {"
+            + "  return document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)"
+            + "    .singleNodeValue"
+            + "});";
+
+    List<String> xpaths = new ArrayList<>();
+
+    for (SelectorIn selector : selectors) {
+      switch (selector.getType()) {
+        case XPATH:
+          xpaths.add(selector.getValue());
+          break;
+        default:
+          throw new InvalidSelectorException(selector, "Unsupported selector type");
+      }
+    }
+
+    return (List<WebElement>) driver.executeScript(script, xpaths);
   }
 }


### PR DESCRIPTION
# visual-java: retrieve data from browser in bulk when possible

> Issue : INT-282

## Description
Adds retrieving data from browser in bulk if possible, such as:
* `getRect()`
* `isDisplayed()`
* `findElement`

Additionally, adds some specialized exceptions containing the faulting object. This is done because sometimes tracking the index of the faulting object would have been troublesome.

## Types of Changes
- New feature (non-breaking change which adds functionality)
- Refactor/improvements
