### PR TITLE
update tests to run with net8.0

### DIFF
--- a/visual-dotnet/SauceLabs.Visual.IntegrationTests/SauceLabs.Visual.IntegrationTests.csproj
+++ b/visual-dotnet/SauceLabs.Visual.IntegrationTests/SauceLabs.Visual.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/visual-dotnet/SauceLabs.Visual.Tests/SauceLabs.Visual.Tests.csproj
+++ b/visual-dotnet/SauceLabs.Visual.Tests/SauceLabs.Visual.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>


### PR DESCRIPTION
# One-line summary

Run tests with net8.0

## Description
net6.0 was deprecated last year
the target is only netstandard2 so this should be fine
it's what selenium uses

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Configuration change
