### PR TITLE
[C#] fix logic so the default region can be accessible

### DIFF
--- a/visual-dotnet/SauceLabs.Visual/Region.cs
+++ b/visual-dotnet/SauceLabs.Visual/Region.cs
@@ -37,7 +37,7 @@ namespace SauceLabs.Visual
         /// <exception cref="VisualClientException"></exception>
         public static Region FromEnvironment()
         {
-            return string.IsNullOrEmpty(EnvVars.Region) ? FromName(EnvVars.Region) : UsWest1;
+            return string.IsNullOrEmpty(EnvVars.Region) ? UsWest1 : FromName(EnvVars.Region);
         }
 
         /// <summary>


### PR DESCRIPTION
# One-line summary

Default region inaccessible with existing logic

## Description
Get an error if Region is not provided

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)
