### PR TITLE
[INT-324] Allow to pass WebDriver to the VisualCheck method

### DIFF
--- a/visual-dotnet/SauceLabs.Visual.IntegrationTests/IntegrationTestAttribute.cs
+++ b/visual-dotnet/SauceLabs.Visual.IntegrationTests/IntegrationTestAttribute.cs
@@ -8,6 +8,23 @@ namespace SauceLabs.Visual.IntegrationTests;
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = false)]
 public class IntegrationTestAttribute : NUnitAttribute, IApplyToTest
 {
+    /// <summary>
+    /// In some cases, such as passing custom ID when the build does not exist, we only can run a single test class.
+    /// This is a limitation of the `VisualClient` SDK, which closes a build with or without a custom ID 
+    /// if it was created by the SDK.
+    /// </summary>
+    public bool SkipIfSingle { get; }
+
+    public IntegrationTestAttribute()
+    {
+        SkipIfSingle = false;
+    }
+
+    public IntegrationTestAttribute(bool skipIfSingle)
+    {
+        SkipIfSingle = skipIfSingle;
+    }
+
     public void ApplyToTest(Test test)
     {
         if (test.RunState == RunState.NotRunnable)
@@ -19,6 +36,12 @@ public class IntegrationTestAttribute : NUnitAttribute, IApplyToTest
         {
             test.RunState = RunState.Ignored;
             test.Properties.Set(PropertyNames.SkipReason, "This test runs only when RUN_IT is \"true\"");
+        }
+
+        if (SkipIfSingle && Environment.GetEnvironmentVariable("RUN_IT_SINGLE") == "true")
+        {
+            test.RunState = RunState.Ignored;
+            test.Properties.Set(PropertyNames.SkipReason, "This test runs only when RUN_IT_SINGLE is NOT \"true\"");
         }
     }
 }

--- a/visual-dotnet/SauceLabs.Visual.IntegrationTests/IntegrationTestAttribute.cs
+++ b/visual-dotnet/SauceLabs.Visual.IntegrationTests/IntegrationTestAttribute.cs
@@ -5,7 +5,7 @@ using NUnit.Framework.Internal;
 
 namespace SauceLabs.Visual.IntegrationTests;
 
-[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = false)]
 public class IntegrationTestAttribute : NUnitAttribute, IApplyToTest
 {
     public void ApplyToTest(Test test)

--- a/visual-dotnet/SauceLabs.Visual.IntegrationTests/LoginPage.cs
+++ b/visual-dotnet/SauceLabs.Visual.IntegrationTests/LoginPage.cs
@@ -20,7 +20,7 @@ public class LoginPage
         Driver = new RemoteWebDriver(sauceUrl, browserOptions);
         Driver.ExecuteScript("sauce:job-name=NUnit C#/.Net Visual Session");
 
-        VisualClient = await VisualClient.Create(Driver, Region.UsWest1);
+        VisualClient = await VisualClient.Create(Driver, Utils.GetSauceRegion());
         TestContext.Progress.WriteLine($"Build: {VisualClient.Build.Url}");
     }
 

--- a/visual-dotnet/SauceLabs.Visual.IntegrationTests/LoginPage.cs
+++ b/visual-dotnet/SauceLabs.Visual.IntegrationTests/LoginPage.cs
@@ -20,7 +20,7 @@ public class LoginPage
         Driver = new RemoteWebDriver(sauceUrl, browserOptions);
         Driver.ExecuteScript("sauce:job-name=NUnit C#/.Net Visual Session");
 
-        VisualClient = await VisualClient.Create(Driver, Utils.GetSauceRegion());
+        VisualClient = await VisualClient.Create(Driver);
         TestContext.Progress.WriteLine($"Build: {VisualClient.Build.Url}");
     }
 

--- a/visual-dotnet/SauceLabs.Visual.IntegrationTests/LoginPageConcurrent.cs
+++ b/visual-dotnet/SauceLabs.Visual.IntegrationTests/LoginPageConcurrent.cs
@@ -14,7 +14,7 @@ public class LoginPageConcurrent
     [OneTimeSetUp]
     public async Task Setup()
     {
-        VisualClient = await VisualClient.Create(Utils.GetSauceRegion());
+        VisualClient = await VisualClient.Create();
         TestContext.Progress.WriteLine($"Build: {VisualClient.Build.Url}");
     }
 

--- a/visual-dotnet/SauceLabs.Visual.IntegrationTests/LoginPageConcurrent.cs
+++ b/visual-dotnet/SauceLabs.Visual.IntegrationTests/LoginPageConcurrent.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using OpenQA.Selenium.Remote;
+
+namespace SauceLabs.Visual.IntegrationTests;
+
+[Parallelizable(ParallelScope.Children)]
+public class LoginPageConcurrent
+{
+    private VisualClient? VisualClient { get; set; }
+
+    [OneTimeSetUp]
+    public async Task Setup()
+    {
+        VisualClient = await VisualClient.Create(Region.UsWest1);
+        TestContext.Progress.WriteLine($"Build: {VisualClient.Build.Url}");
+    }
+
+    [IntegrationTest]
+    [Test]
+    public async Task LoginPage_ShouldOpen1()
+    {
+        await UsingDriver(async (driver) =>
+        {
+            driver.Navigate().GoToUrl("https://www.saucedemo.com");
+            await VisualClient.VisualCheck(driver, "Login Page");
+        });
+    }
+
+    [IntegrationTest]
+    [Test]
+    public async Task LoginPage_ShouldOpen2()
+    {
+        await UsingDriver(async (driver) =>
+        {
+            driver.Navigate().GoToUrl("https://www.saucedemo.com");
+            await VisualClient.VisualCheck(driver, "Login Page");
+        });
+    }
+
+    [IntegrationTest]
+    [Test]
+    public async Task LoginPage_ShouldOpen3()
+    {
+        await UsingDriver(async (driver) =>
+        {
+            driver.Navigate().GoToUrl("https://www.saucedemo.com");
+            await VisualClient.VisualCheck(driver, "Login Page");
+        });
+    }
+
+    private async Task UsingDriver(Func<RemoteWebDriver, Task> func)
+    {
+        var browserOptions = Utils.GetBrowserOptions();
+        var sauceOptions = Utils.GetSauceOptions();
+        browserOptions.AddAdditionalOption("sauce:options", sauceOptions);
+
+        var sauceUrl = Utils.GetOnDemandURL();
+
+        var driver = new RemoteWebDriver(sauceUrl, browserOptions);
+        try
+        {
+            await func(driver);
+        }
+        finally
+        {
+            driver.Quit();
+        }
+    }
+
+    [OneTimeTearDown]
+    public async Task Teardown()
+    {
+        await VisualClient.Finish();
+        VisualClient?.Dispose();
+    }
+}

--- a/visual-dotnet/SauceLabs.Visual.IntegrationTests/LoginPageConcurrent.cs
+++ b/visual-dotnet/SauceLabs.Visual.IntegrationTests/LoginPageConcurrent.cs
@@ -6,7 +6,7 @@ using OpenQA.Selenium.Remote;
 namespace SauceLabs.Visual.IntegrationTests;
 
 [Parallelizable(ParallelScope.Children)]
-[IntegrationTest]
+[IntegrationTest(skipIfSingle: true)]
 public class LoginPageConcurrent
 {
     private VisualClient? VisualClient { get; set; }

--- a/visual-dotnet/SauceLabs.Visual.IntegrationTests/LoginPageConcurrent.cs
+++ b/visual-dotnet/SauceLabs.Visual.IntegrationTests/LoginPageConcurrent.cs
@@ -13,7 +13,7 @@ public class LoginPageConcurrent
     [OneTimeSetUp]
     public async Task Setup()
     {
-        VisualClient = await VisualClient.Create(Region.UsWest1);
+        VisualClient = await VisualClient.Create(Utils.GetSauceRegion());
         TestContext.Progress.WriteLine($"Build: {VisualClient.Build.Url}");
     }
 
@@ -73,6 +73,6 @@ public class LoginPageConcurrent
     public async Task Teardown()
     {
         await VisualClient.Finish();
-        VisualClient?.Dispose();
+        VisualClient.Dispose();
     }
 }

--- a/visual-dotnet/SauceLabs.Visual.IntegrationTests/LoginPageConcurrent.cs
+++ b/visual-dotnet/SauceLabs.Visual.IntegrationTests/LoginPageConcurrent.cs
@@ -6,6 +6,7 @@ using OpenQA.Selenium.Remote;
 namespace SauceLabs.Visual.IntegrationTests;
 
 [Parallelizable(ParallelScope.Children)]
+[IntegrationTest]
 public class LoginPageConcurrent
 {
     private VisualClient? VisualClient { get; set; }
@@ -17,7 +18,6 @@ public class LoginPageConcurrent
         TestContext.Progress.WriteLine($"Build: {VisualClient.Build.Url}");
     }
 
-    [IntegrationTest]
     [Test]
     public async Task LoginPage_ShouldOpen1()
     {
@@ -28,7 +28,6 @@ public class LoginPageConcurrent
         });
     }
 
-    [IntegrationTest]
     [Test]
     public async Task LoginPage_ShouldOpen2()
     {
@@ -39,7 +38,6 @@ public class LoginPageConcurrent
         });
     }
 
-    [IntegrationTest]
     [Test]
     public async Task LoginPage_ShouldOpen3()
     {

--- a/visual-dotnet/SauceLabs.Visual.IntegrationTests/Utils.cs
+++ b/visual-dotnet/SauceLabs.Visual.IntegrationTests/Utils.cs
@@ -40,22 +40,22 @@ internal static class Utils
         return accessKey;
     }
 
-    public static string GetSauceRegion()
+    public static Region GetSauceRegion()
     {
         var region = Environment.GetEnvironmentVariable("SAUCE_REGION");
         if (string.IsNullOrEmpty(region))
         {
-            return "us-west-1";
+            return Region.UsWest1;
         }
 
-        return region;
+        return Region.FromName(region);
     }
 
     public static Uri GetOnDemandURL()
     {
         var regionName = GetSauceRegion();
-        var tld = regionName == "staging" ? "net" : "com";
-        return new Uri("https://ondemand." + regionName + ".saucelabs." + tld + "/wd/hub");
+        var tld = regionName.Name == "staging" ? "net" : "com";
+        return new Uri("https://ondemand." + regionName.Name + ".saucelabs." + tld + "/wd/hub");
     }
 
     public static DriverOptions GetBrowserOptions()

--- a/visual-dotnet/SauceLabs.Visual/ConcurrentVisualClient.cs
+++ b/visual-dotnet/SauceLabs.Visual/ConcurrentVisualClient.cs
@@ -109,7 +109,8 @@ namespace SauceLabs.Visual
                 return res.EnsureValidResponse().Result;
             });
 
-            return await VisualCheckBaseAsync(name, options, jobId, sessionId, sessionMetadata.Blob);
+            var metadata = new WebDriverMetadata(sessionId, jobId, sessionMetadata.Blob);
+            return await VisualCheckBaseAsync(name, options, metadata);
         }
     }
 }

--- a/visual-dotnet/SauceLabs.Visual/Utils/WebDriverMetadata.cs
+++ b/visual-dotnet/SauceLabs.Visual/Utils/WebDriverMetadata.cs
@@ -1,0 +1,16 @@
+namespace SauceLabs.Visual.Utils
+{
+    internal class WebDriverMetadata
+    {
+        public string SessionId { get; }
+        public string JobId { get; }
+        public string SessionMetadataBlob { get; }
+
+        public WebDriverMetadata(string sessionId, string jobId, string sessionMetadataBlob)
+        {
+            SessionId = sessionId;
+            JobId = jobId;
+            SessionMetadataBlob = sessionMetadataBlob;
+        }
+    }
+}

--- a/visual-dotnet/SauceLabs.Visual/Utils/WebDriverMetadataCache.cs
+++ b/visual-dotnet/SauceLabs.Visual/Utils/WebDriverMetadataCache.cs
@@ -1,0 +1,27 @@
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace SauceLabs.Visual.Utils
+{
+    internal class WebDriverMetadataCache
+    {
+        private readonly ConcurrentDictionary<string, WebDriverMetadata> _cache = new ConcurrentDictionary<string, WebDriverMetadata>();
+
+        public async Task<WebDriverMetadata> GetMetadata(VisualApi api, string sessionId, string jobId)
+        {
+            if (_cache.TryGetValue(sessionId, out var cached))
+            {
+                return cached;
+            }
+
+            var response = await api.WebDriverSessionInfo(jobId, sessionId);
+            var metadataBlob = response.EnsureValidResponse().Result.Blob;
+            var metadata = new WebDriverMetadata(sessionId, jobId, metadataBlob);
+
+            // We don't care if this fails
+            _cache.TryAdd(sessionId, metadata);
+
+            return metadata;
+        }
+    }
+}

--- a/visual-dotnet/SauceLabs.Visual/VisualClientBase.cs
+++ b/visual-dotnet/SauceLabs.Visual/VisualClientBase.cs
@@ -62,7 +62,7 @@ namespace SauceLabs.Visual
         }
 
         internal async Task<string> VisualCheckBaseAsync(string name,
-            VisualCheckOptions options, string jobId, string sessionId, string? sessionMetadataBlob)
+            VisualCheckOptions options, WebDriverMetadata wdMetadata)
         {
             var ignoredRegions =
                 IgnoredRegions.SplitIgnoredRegions(options.Regions, options.IgnoreRegions, options.IgnoreElements);
@@ -76,12 +76,12 @@ namespace SauceLabs.Visual
             var result = (await Api.CreateSnapshotFromWebDriver(new CreateSnapshotFromWebDriverIn(
                 buildUuid: Build.Id,
                 name: name,
-                jobId: jobId,
+                jobId: wdMetadata.JobId,
                 diffingMethod: options.DiffingMethod ?? DiffingMethod.Balanced,
                 regions: ignoredRegions.RegionsIn,
                 ignoredElements: ignoredRegions.ElementsIn,
-                sessionId: sessionId,
-                sessionMetadata: sessionMetadataBlob ?? "",
+                sessionId: wdMetadata.SessionId,
+                sessionMetadata: wdMetadata.SessionMetadataBlob ?? "",
                 captureDom: options.CaptureDom ?? CaptureDom,
                 clipElement: options.ClipElement?.GetElementId(),
                 suiteName: options.SuiteName,


### PR DESCRIPTION
# Allow to pass `WebDriver` to the `VisualCheck` method

> Issue : INT-324

## Description
If you want to use `VisualClient` concurrently with multiple drivers, there's no current way to do so.

One could create multiple `VisualClient`s, but this approach has an issue with closing the clients. Every client by design will have the same build, and closing any one of them will cause others to start failing, as they will submit their snapshots to an already closed build.

### Solution
To allow for using multiple drivers with a single build, you can create `VIsualClient` without specifying a `WebDriver` instance. You specify it then in `VisualCheck` method. Using the `VisualCheck` method without specifying a `WebDriver` instance will throw an exception if the `VisualClient` instance was initialized without a driver.

The `VisualClient` instance has to be created once and disposed once per concurrent test. Using multiple `VisualClient` with multiple builds is currently not possible and changing that would be a breaking change. One solution is to potentially add an option like `DoNotReuseBuild`, but that is a topic for a different pull request.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)

