### PR TITLE
[no-ticket] Improvements to integration tests

### DIFF
--- a/tests/env-vars-build-id.spec.ts
+++ b/tests/env-vars-build-id.spec.ts
@@ -3,7 +3,7 @@ import { RE_VISUAL_BUILD_ID, SAUCE_VISUAL_BUILD_NAME } from './utils/helpers';
 import { execute } from './utils/process';
 import { FileHandle } from 'fs/promises';
 
-const region = 'us-west-1' as SauceRegion;
+const region = (process.env.SAUCE_REGION ?? 'us-west-1') as SauceRegion;
 
 const visualApi = getApi({
   region,

--- a/tests/env-vars-build-id.spec.ts
+++ b/tests/env-vars-build-id.spec.ts
@@ -68,7 +68,7 @@ describe('Build ID env var', () => {
       expect(build).toBeTruthy();
       expect(build?.id).toEqual(buildId);
       expect(build?.name).toEqual(SAUCE_VISUAL_BUILD_NAME);
-      expect(build?.diffs?.nodes.length).toBe(1);
+      expect(build?.diffs?.nodes.length).toBeGreaterThanOrEqual(1);
       expect(build?.status).toBe(BuildStatus.Running);
     },
     15 * 1000

--- a/tests/env-vars-custom-id.spec.ts
+++ b/tests/env-vars-custom-id.spec.ts
@@ -7,7 +7,7 @@ import { execute } from './utils/process';
 import { FileHandle } from 'fs/promises';
 import { randomBytes } from 'crypto';
 
-const region = 'us-west-1' as SauceRegion;
+const region = (process.env.SAUCE_REGION ?? 'us-west-1') as SauceRegion;
 
 const visualApi = getApi({
   region,

--- a/tests/env-vars-custom-id.spec.ts
+++ b/tests/env-vars-custom-id.spec.ts
@@ -78,7 +78,7 @@ describe('Custom ID env var', () => {
       expect(build).toBeTruthy();
       expect(build?.id).toEqual(externalBuildId);
       expect(build?.name).toEqual(SAUCE_VISUAL_BUILD_NAME);
-      expect(build?.diffs?.nodes.length).toBe(1);
+      expect(build?.diffs?.nodes.length).toBeGreaterThanOrEqual(1);
       expect(build?.status).toBe(BuildStatus.Running);
     },
     15 * 1000

--- a/tests/env-vars-unlinked-custom-id.spec.ts
+++ b/tests/env-vars-unlinked-custom-id.spec.ts
@@ -77,7 +77,7 @@ describe('Unlinked custom ID env var', () => {
 
       const build = await visualApi.buildWithDiffs(buildId);
       expect(build).toBeTruthy();
-      expect(build?.diffs?.nodes.length).toBe(1);
+      expect(build?.diffs?.nodes.length).toBeGreaterThanOrEqual(1);
     },
     60 * 1000
   );

--- a/tests/env-vars-unlinked-custom-id.spec.ts
+++ b/tests/env-vars-unlinked-custom-id.spec.ts
@@ -9,7 +9,7 @@ import { execute } from './utils/process';
 import { FileHandle } from 'fs/promises';
 import { randomBytes } from 'crypto';
 
-const region = 'us-west-1' as SauceRegion;
+const region = (process.env.SAUCE_REGION ?? 'us-west-1') as SauceRegion;
 
 const visualApi = getApi({
   region,

--- a/tests/env-vars-unlinked-custom-id.spec.ts
+++ b/tests/env-vars-unlinked-custom-id.spec.ts
@@ -1,0 +1,84 @@
+import { BuildStatus, SauceRegion, getApi } from '@saucelabs/visual';
+import {
+  RE_VISUAL_BUILD_ID,
+  RE_VISUAL_BUILD_LINK,
+  SAUCE_VISUAL_BUILD_NAME,
+  waitStatusForBuild,
+} from './utils/helpers';
+import { execute } from './utils/process';
+import { FileHandle } from 'fs/promises';
+import { randomBytes } from 'crypto';
+
+const region = 'us-west-1' as SauceRegion;
+
+const visualApi = getApi({
+  region,
+  user: process.env.SAUCE_USERNAME!,
+  key: process.env.SAUCE_ACCESS_KEY!,
+});
+
+const customId = randomBytes(20).toString('hex');
+
+let fileOutput: FileHandle | undefined;
+let dockerOutput = '';
+let buildId = '';
+
+describe('Unlinked custom ID env var', () => {
+  it(
+    'runs the docker image with an unlinked custom ID in place',
+    async () => {
+      const result = await execute(
+        `docker run --rm -e SAUCE_USERNAME -e SAUCE_ACCESS_KEY \\
+        -e SAUCE_VISUAL_BUILD_NAME \\
+        -e SAUCE_VISUAL_CUSTOM_ID \\
+        -e SAUCE_REGION \\
+        -e RUN_IT_SINGLE \\
+        ${process.env.CONTAINER_IMAGE_NAME}`,
+        {
+          displayOutputOnFailure: true,
+          pipeOutput: false,
+          fileOutput,
+          env: {
+            SAUCE_VISUAL_BUILD_NAME: SAUCE_VISUAL_BUILD_NAME,
+            SAUCE_VISUAL_CUSTOM_ID: customId,
+            SAUCE_REGION: region,
+            RUN_IT_SINGLE: 'true'
+          },
+        }
+      );
+
+      // Storybook container exits with code 1, this is expected behaviour
+      if (!process.env.CONTAINER_IMAGE_NAME?.includes('storybook')) {
+        expect(result.statusCode).toEqual(0);
+      }
+      dockerOutput = result.stdout;
+    },
+    2 * 60 * 1000
+  );
+
+  it('returns a new build ID', async () => {
+    expect(dockerOutput.length).toBeGreaterThan(0);
+
+    const links = [...dockerOutput.matchAll(RE_VISUAL_BUILD_LINK)];
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    buildId = links[0][4];
+    expect(buildId).toMatch(RE_VISUAL_BUILD_ID);
+  });
+
+  it(
+    'build is completed',
+    async () => {
+      expect(buildId).toMatch(RE_VISUAL_BUILD_ID);
+
+      await waitStatusForBuild(visualApi, buildId, [BuildStatus.Unapproved], {
+        refreshRate: 1000,
+        retries: 30,
+      });
+
+      const build = await visualApi.buildWithDiffs(buildId);
+      expect(build).toBeTruthy();
+      expect(build?.diffs?.nodes.length).toBe(1);
+    },
+    60 * 1000
+  );
+});

--- a/tests/env-vars.spec.ts
+++ b/tests/env-vars.spec.ts
@@ -11,7 +11,7 @@ import {
 import { execute } from './utils/process';
 import { FileHandle } from 'fs/promises';
 
-const region = 'us-west-1' as SauceRegion;
+const region = (process.env.SAUCE_REGION ?? 'us-west-1') as SauceRegion;
 
 const visualApi = getApi({
   region,


### PR DESCRIPTION
# Improvements to integration tests

## Description
Some improvements to integration tests:
* use `SAUCE_REGION`
* split custom ID tests into one providing the custom ID and the other not providing it
* allow for more than 1 diff to be generated in tests

I need this as a part of https://github.com/saucelabs/visual-sdks/pull/244, but I figured this can impact more projects, so better to make a separate pull request for this.

## Types of Changes

- Refactor/improvements
