### PR TITLE
Biq 1041 cypress 15 support

### DIFF
--- a/visual-js/.changeset/nice-fishes-obey.md
+++ b/visual-js/.changeset/nice-fishes-obey.md
@@ -1,5 +1,0 @@
----
-"@saucelabs/cypress-visual-plugin": minor
----
-
-bump node, cypress versions

--- a/visual-js/.changeset/nice-fishes-obey.md
+++ b/visual-js/.changeset/nice-fishes-obey.md
@@ -1,0 +1,5 @@
+---
+"@saucelabs/cypress-visual-plugin": minor
+---
+
+bump node, cypress versions

--- a/visual-js/.changeset/slimy-readers-decide.md
+++ b/visual-js/.changeset/slimy-readers-decide.md
@@ -1,0 +1,5 @@
+---
+"@saucelabs/cypress-visual-plugin": patch
+---
+
+bump cypress versions

--- a/visual-js/package-lock.json
+++ b/visual-js/package-lock.json
@@ -1430,6 +1430,7 @@
     "node_modules/@cypress/request": {
       "version": "3.0.5",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -1457,6 +1458,7 @@
     "node_modules/@cypress/xvfb": {
       "version": "1.2.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^3.1.0",
         "lodash.once": "^4.1.1"
@@ -1465,6 +1467,7 @@
     "node_modules/@cypress/xvfb/node_modules/debug": {
       "version": "3.2.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -4766,14 +4769,6 @@
       "version": "4.3.20",
       "license": "MIT"
     },
-    "node_modules/@types/cypress": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cypress": "*"
-      }
-    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4913,11 +4908,13 @@
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/sizzle": {
       "version": "2.3.8",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -6048,7 +6045,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/archiver": {
       "version": "5.3.2",
@@ -6298,6 +6296,7 @@
     "node_modules/asn1": {
       "version": "0.2.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -6318,6 +6317,7 @@
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -6363,6 +6363,7 @@
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -6403,13 +6404,15 @@
     "node_modules/aws-sign2": {
       "version": "0.7.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/aws4": {
       "version": "1.13.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/axe-core": {
       "version": "4.10.0",
@@ -6634,6 +6637,7 @@
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -6669,11 +6673,13 @@
     },
     "node_modules/blob-util": {
       "version": "2.0.2",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/boxen": {
       "version": "5.1.2",
@@ -6884,6 +6890,7 @@
     "node_modules/cachedir": {
       "version": "2.4.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6988,7 +6995,8 @@
     },
     "node_modules/caseless": {
       "version": "0.12.0",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -7146,6 +7154,7 @@
     "node_modules/check-more-types": {
       "version": "2.24.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -7630,6 +7639,7 @@
       "version": "13.15.0",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cypress/request": "^3.0.4",
         "@cypress/xvfb": "^1.2.4",
@@ -7684,6 +7694,7 @@
     "node_modules/cypress/node_modules/commander": {
       "version": "6.2.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -7691,6 +7702,7 @@
     "node_modules/cypress/node_modules/execa": {
       "version": "4.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -7712,6 +7724,7 @@
     "node_modules/cypress/node_modules/fs-extra": {
       "version": "9.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -7725,6 +7738,7 @@
     "node_modules/cypress/node_modules/get-stream": {
       "version": "5.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -7738,6 +7752,7 @@
     "node_modules/cypress/node_modules/human-signals": {
       "version": "1.1.1",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.12.0"
       }
@@ -7745,6 +7760,7 @@
     "node_modules/cypress/node_modules/jsonfile": {
       "version": "6.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -7755,6 +7771,7 @@
     "node_modules/cypress/node_modules/listr2": {
       "version": "3.14.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^2.1.0",
         "colorette": "^2.0.16",
@@ -7779,11 +7796,13 @@
     },
     "node_modules/cypress/node_modules/proxy-from-env": {
       "version": "1.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -7840,7 +7859,8 @@
     },
     "node_modules/dayjs": {
       "version": "1.11.13",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debounce": {
       "version": "1.2.1",
@@ -8333,6 +8353,7 @@
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -8922,7 +8943,8 @@
     },
     "node_modules/eventemitter2": {
       "version": "6.4.7",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -8957,6 +8979,7 @@
     "node_modules/executable": {
       "version": "4.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pify": "^2.2.0"
       },
@@ -8967,6 +8990,7 @@
     "node_modules/executable/node_modules/pify": {
       "version": "2.3.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9533,7 +9557,8 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/extendable-error": {
       "version": "0.1.7",
@@ -9608,7 +9633,8 @@
       "engines": [
         "node >=0.6.0"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-copy": {
       "version": "3.0.2",
@@ -9973,6 +9999,7 @@
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -10303,6 +10330,7 @@
     "node_modules/getos": {
       "version": "3.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "async": "^3.2.0"
       }
@@ -10310,6 +10338,7 @@
     "node_modules/getpass": {
       "version": "0.1.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
@@ -10345,6 +10374,7 @@
     "node_modules/global-dirs": {
       "version": "3.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ini": "2.0.0"
       },
@@ -10801,6 +10831,7 @@
     "node_modules/http-signature": {
       "version": "1.4.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^2.0.2",
@@ -10981,6 +11012,7 @@
     "node_modules/ini": {
       "version": "2.0.0",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -11153,6 +11185,7 @@
     "node_modules/is-ci": {
       "version": "3.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ci-info": "^3.2.0"
       },
@@ -11269,6 +11302,7 @@
     "node_modules/is-installed-globally": {
       "version": "0.4.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "global-dirs": "^3.0.0",
         "is-path-inside": "^3.0.2"
@@ -11532,7 +11566,8 @@
     },
     "node_modules/isstream": {
       "version": "0.1.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -12371,7 +12406,8 @@
     },
     "node_modules/jsbn": {
       "version": "0.1.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jsdom": {
       "version": "24.1.3",
@@ -12432,7 +12468,8 @@
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
+      "license": "(AFL-2.1 OR BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -12463,7 +12500,8 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/json-to-pretty-yaml": {
       "version": "1.2.2",
@@ -12514,6 +12552,7 @@
         "node >=0.6.0"
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -12587,6 +12626,7 @@
     "node_modules/lazy-ass": {
       "version": "1.6.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "> 0.8"
       }
@@ -12811,7 +12851,8 @@
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -14017,7 +14058,8 @@
     },
     "node_modules/ospath": {
       "version": "1.2.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/outdent": {
       "version": "0.5.0",
@@ -14381,7 +14423,8 @@
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -14622,6 +14665,7 @@
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -15080,6 +15124,7 @@
     "node_modules/qs": {
       "version": "6.13.0",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -15446,6 +15491,7 @@
     "node_modules/request-progress": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "throttleit": "^1.0.0"
       }
@@ -16128,6 +16174,7 @@
     "node_modules/sshpk": {
       "version": "1.18.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -16577,6 +16624,7 @@
     "node_modules/throttleit": {
       "version": "1.0.1",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -16925,6 +16973,7 @@
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -16934,7 +16983,8 @@
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
-      "license": "Unlicense"
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -17444,6 +17494,7 @@
         "node >=0.6.0"
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -17452,14 +17503,16 @@
     },
     "node_modules/verror/node_modules/core-util-is": {
       "version": "1.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/verror/node_modules/extsprintf": {
       "version": "1.4.1",
       "engines": [
         "node >=0.6.0"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
@@ -18403,7 +18456,6 @@
       },
       "devDependencies": {
         "@tsconfig/node18": "^2.0.1",
-        "@types/cypress": "^1.1.3",
         "@types/node": "^20.4.4",
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "@typescript-eslint/parser": "^5.59.1",
@@ -18419,10 +18471,10 @@
         "typescript": "^5.1.6"
       },
       "engines": {
-        "node": "^16.13 || >=18"
+        "node": "^20 || ^22 || >=24"
       },
       "peerDependencies": {
-        "cypress": "^12.0.0 || ^13.0.0"
+        "cypress": "^13.0.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "visual-cypress/node_modules/chalk": {
@@ -18799,7 +18851,7 @@
     },
     "visual-storybook": {
       "name": "@saucelabs/visual-storybook",
-      "version": "0.10.9",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@saucelabs/visual": "^0.16.0",

--- a/visual-js/visual-cypress/package.json
+++ b/visual-js/visual-cypress/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "engines": {
-    "node": "^16.13 || >=18"
+    "node": "^20 || ^22 || >=24"
   },
   "typeScriptVersion": "5.1.6",
   "keywords": [
@@ -34,7 +34,7 @@
     "./package.json": "./package.json"
   },
   "peerDependencies": {
-    "cypress": "^12.0.0 || ^13.0.0"
+    "cypress": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
   },
   "dependencies": {
     "@saucelabs/visual": "^0.16.0",
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@tsconfig/node18": "^2.0.1",
-    "@types/cypress": "^1.1.3",
     "@types/node": "^20.4.4",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^5.59.1",

--- a/visual-js/visual-cypress/package.json
+++ b/visual-js/visual-cypress/package.json
@@ -11,9 +11,6 @@
     "build",
     "README.md"
   ],
-  "engines": {
-    "node": "^20 || ^22 || >=24"
-  },
   "typeScriptVersion": "5.1.6",
   "keywords": [
     "cypress",


### PR DESCRIPTION
# One-line summary
Add support for cypress 14 and 15.

## Description
To add Cypress version 15, support for Node 16 and 18 needs to be dropped.

## Types of Changes

_What types of changes does your code introduce? Keep the ones that apply:_
- Configuration change

## Testing strategy

e2e and manual testing

## Deployment Notes

These should highlight any db migrations, feature toggles, etc.
