### PR TITLE
feat: Pinning the version of kotlin stdlib to 2.4.0

### DIFF
--- a/visual-espresso/gradle/libs.versions.toml
+++ b/visual-espresso/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "8.5.2"
 apolloGraphQL = "3.8.5"
+kotlin = "2.4.0"
 jsoup = "1.18.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -11,6 +12,7 @@ uiautomator = "2.2.0"
 vanniktechMavenPublish = "0.30.0"
 
 [libraries]
+kotlin-bom = { group = "org.jetbrains.kotlin", name = "kotlin-bom", version.ref = "kotlin" }
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }

--- a/visual-espresso/visual/build.gradle
+++ b/visual-espresso/visual/build.gradle
@@ -55,6 +55,8 @@ String getProperty(String name, String defaultValue) {
 }
 
 dependencies {
+    implementation platform(libs.kotlin.bom)
+
     implementation libs.appcompat
     implementation libs.material
     implementation libs.junit

--- a/visual-espresso/visual/build.gradle
+++ b/visual-espresso/visual/build.gradle
@@ -56,7 +56,6 @@ String getProperty(String name, String defaultValue) {
 
 dependencies {
     implementation platform(libs.kotlin.bom)
-
     implementation libs.appcompat
     implementation libs.material
     implementation libs.junit


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thank you for contributing to the `visual-sdks` project!**
**A well described pull request helps maintainers quickly review and merge your change**
-->

# One-line summary

> Issue : BIQ-1139

## Description

In this PR I am bumping a version of kotlin-stdlib. This package is not used directly but is being pulled in by other packages.
So I pinned the version of the kotlin-stdlib to be 2.4.0

## Types of Changes

_What types of changes does your code introduce? Keep the ones that apply:_

- Configuration change

## Testing strategy

Run unit tests form the Iris/e2e repo while using the latest espress sdk version

## Deployment Notes

We will trigger the release pipeline
