### PR TITLE
Migrating Espresso SDK publishing from legacy OSSRH to Sonatype Central Portal

### DIFF
--- a/.github/workflows/espresso-release.yml
+++ b/.github/workflows/espresso-release.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          server-id: ossrh
 
       - name: Set up Git
         if: ${{ steps.prep.outputs.tag_name == '' }}

--- a/visual-espresso/visual/build.gradle
+++ b/visual-espresso/visual/build.gradle
@@ -74,7 +74,7 @@ ext {
 
 mavenPublishing {
     configure(new AndroidSingleVariantLibrary("release", true, true))
-    publishToMavenCentral(SonatypeHost.DEFAULT)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
     coordinates(android.namespace, "${artifactName}", android.defaultConfig.versionName)
 


### PR DESCRIPTION
# Migrate Espresso SDK publishing from legacy OSSRH to Sonatype Central Portal

## Description

The Espresso release pipeline [was failing](https://github.com/saucelabs/visual-sdks/actions/runs/29335353188/job/87093114875) at `:visual:createStagingRepository` with `Cannot get stagingProfiles for account ***: (402)` because the legacy OSSRH staging API (`oss.sonatype.org`) was [shut down on June 30, 2025](https://central.sonatype.org/pages/ossrh-eol/).

<img width="1224" height="936" alt="image" src="https://github.com/user-attachments/assets/ac6ea8d9-0939-4ea5-b003-ede7bccff9c5" />


In this PR I am migrating the publishing config to the new Central Publisher Portal:

- `visual-espresso/visual/build.gradle`: `SonatypeHost.DEFAULT` → `SonatypeHost.CENTRAL_PORTAL` (supported by the vanniktech maven-publish plugin 0.30.0 we already use)
- `.github/workflows/espresso-release.yml`: removed the stale `server-id: ossrh` from the `setup-java` step (only relevant for Maven `settings.xml`, never read by Gradle)

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
- Configuration change

## Testing strategy

- Verified locally that the Gradle config evaluates and `publishAndReleaseToMavenCentral` (the task the release workflow invokes) resolves correctly with the new host.
- Full end-to-end validation happens on the next run of the `Espresso (Release)` workflow.