### PR TITLE
[Espresso SDK] Bumped version of apollo to 5.0.1

### DIFF
--- a/visual-espresso/gradle/libs.versions.toml
+++ b/visual-espresso/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
-agp = "8.5.2"
-apolloGraphQL = "3.8.5"
-kotlin = "2.4.0"
+agp = "8.6.1"
+apolloGraphQL = "5.0.1"
 jsoup = "1.18.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -12,7 +11,6 @@ uiautomator = "2.2.0"
 vanniktechMavenPublish = "0.30.0"
 
 [libraries]
-kotlin-bom = { group = "org.jetbrains.kotlin", name = "kotlin-bom", version.ref = "kotlin" }
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
@@ -20,11 +18,10 @@ espresso-core = { group = "androidx.test.espresso", name = "espresso-core", vers
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
-apollo-runtime = { group = "com.apollographql.apollo3", name = "apollo-runtime", version.ref = "apolloGraphQL" }
-apollo-rx3-support = { group = "com.apollographql.apollo3", name = "apollo-rx3-support", version.ref = "apolloGraphQL" }
+apollo-runtime = { group = "com.apollographql.apollo", name = "apollo-runtime", version.ref = "apolloGraphQL" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-apollographql = { id = "com.apollographql.apollo3", version.ref = "apolloGraphQL" }
+apollographql = { id = "com.apollographql.apollo", version.ref = "apolloGraphQL" }
 vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktechMavenPublish" }

--- a/visual-espresso/visual/build.gradle
+++ b/visual-espresso/visual/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace 'com.saucelabs.visual'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         minSdk 21
@@ -55,12 +55,10 @@ String getProperty(String name, String defaultValue) {
 }
 
 dependencies {
-    implementation platform(libs.kotlin.bom)
     implementation libs.appcompat
     implementation libs.material
     implementation libs.junit
     implementation libs.apollo.runtime
-    implementation libs.apollo.rx3.support
     implementation libs.espresso.core
     implementation libs.uiautomator
     implementation libs.jsoup

--- a/visual-espresso/visual/src/main/java/com/saucelabs/visual/graphql/GraphQLClient.java
+++ b/visual-espresso/visual/src/main/java/com/saucelabs/visual/graphql/GraphQLClient.java
@@ -10,6 +10,7 @@ import com.apollographql.apollo.api.Error;
 import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.exception.ApolloException;
 import com.saucelabs.visual.BuildConfig;
 import com.saucelabs.visual.DataCenter;
 import com.saucelabs.visual.exception.VisualApiException;
@@ -59,7 +60,10 @@ public class GraphQLClient {
                     (scope, continuation) -> call.execute(continuation));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new VisualApiException("Interrupted while executing GraphQL call");
+            throw new VisualApiException("Interrupted while executing GraphQL call", e);
+        } catch (ApolloException e) {
+            String message = e.getMessage() != null ? e.getMessage() : "GraphQL call failed";
+            throw new VisualApiException(message, e);
         }
     }
 
@@ -76,7 +80,10 @@ public class GraphQLClient {
             }
             throw new VisualApiException(message.toString());
         } else if (response.exception != null) {
-            throw new VisualApiException(response.exception.getMessage());
+            String message = response.exception.getMessage() != null
+                    ? response.exception.getMessage()
+                    : "GraphQL request failed";
+            throw new VisualApiException(message, response.exception);
         } else {
             throw new VisualApiException("Unexpected GraphQL error");
         }

--- a/visual-espresso/visual/src/main/java/com/saucelabs/visual/graphql/GraphQLClient.java
+++ b/visual-espresso/visual/src/main/java/com/saucelabs/visual/graphql/GraphQLClient.java
@@ -3,20 +3,19 @@ package com.saucelabs.visual.graphql;
 import android.text.TextUtils;
 import android.util.Base64;
 
-import com.apollographql.apollo3.ApolloCall;
-import com.apollographql.apollo3.ApolloClient;
-import com.apollographql.apollo3.api.ApolloResponse;
-import com.apollographql.apollo3.api.Error;
-import com.apollographql.apollo3.api.Mutation;
-import com.apollographql.apollo3.api.Operation;
-import com.apollographql.apollo3.api.Query;
-import com.apollographql.apollo3.exception.ApolloHttpException;
-import com.apollographql.apollo3.rx3.Rx3Apollo;
+import com.apollographql.apollo.ApolloCall;
+import com.apollographql.apollo.ApolloClient;
+import com.apollographql.apollo.api.ApolloResponse;
+import com.apollographql.apollo.api.Error;
+import com.apollographql.apollo.api.Mutation;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
 import com.saucelabs.visual.BuildConfig;
 import com.saucelabs.visual.DataCenter;
 import com.saucelabs.visual.exception.VisualApiException;
 
-import io.reactivex.rxjava3.core.Single;
+import kotlin.coroutines.EmptyCoroutineContext;
+import kotlinx.coroutines.BuildersKt;
 
 public class GraphQLClient {
 
@@ -45,25 +44,22 @@ public class GraphQLClient {
     }
 
     public <D extends Query.Data> D executeQuery(Query<D> q) {
-        ApolloCall<D> call = client.query(q);
-        Single<ApolloResponse<D>> single = Rx3Apollo.single(call);
-        try {
-            ApolloResponse<D> response = single.blockingGet();
-            return handleResponse(response);
-        } catch (ApolloHttpException e) {
-            throw new VisualApiException(e.getMessage());
-        }
+        return handleResponse(executeBlocking(client.query(q)));
     }
 
-
     public <D extends Mutation.Data> D executeMutation(Mutation<D> m) {
-        ApolloCall<D> call = client.mutation(m);
-        Single<ApolloResponse<D>> single = Rx3Apollo.single(call);
+        return handleResponse(executeBlocking(client.mutation(m)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <D extends Operation.Data> ApolloResponse<D> executeBlocking(ApolloCall<D> call) {
         try {
-            ApolloResponse<D> response = single.blockingGet();
-            return handleResponse(response);
-        } catch (ApolloHttpException e) {
-            throw new VisualApiException(e.getMessage());
+            return (ApolloResponse<D>) BuildersKt.runBlocking(
+                    EmptyCoroutineContext.INSTANCE,
+                    (scope, continuation) -> call.execute(continuation));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new VisualApiException("Interrupted while executing GraphQL call");
         }
     }
 
@@ -79,6 +75,8 @@ public class GraphQLClient {
                 message.append(error.getMessage());
             }
             throw new VisualApiException(message.toString());
+        } else if (response.exception != null) {
+            throw new VisualApiException(response.exception.getMessage());
         } else {
             throw new VisualApiException("Unexpected GraphQL error");
         }


### PR DESCRIPTION
# [visual-espresso] Migrate Apollo 3.8.5 → 5.0.1 to clear kotlin-stdlib CVE

> Issue: BIQ-1147

## Description

In this PR I am upgrading Apollo to 5.0.1 so downstream consumers naturally resolve kotlin-stdlib ≥ 2.1.0:

As a bonus, removing the kotlin 2.4.0 pin clears the non-fatal `Module was compiled with an incompatible version of Kotlin` lint errors seen in CI.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
- Configuration change
- Refactor/improvements

## Testing strategy

- `./gradlew :visual:build` (incl. lint) passes with Gradle 8.7 / AGP 8.6.1 / JDK 17
- `publishToMavenLocal` + throwaway consumer: `dependencyInsight` shows every `kotlin-stdlib`
  edge resolving to 2.2.21 (≥ 2.1.0 → Snyk issue cleared); legacy `kotlin-stdlib-jdk7/8:1.8.0`
  entries are JetBrains' own alignment constraints with no known vulnerabilities
- Sample consumer app compiled against the published AAR (`assembleDebugAndroidTest`),
  exercising the exposed Apollo API surface (`GraphQLClient(ApolloClient)`, `executeMutation`)
- Device `SmokeTest` on an android-34 emulator: 2/2 passed, snapshots visible in Sauce Visual
  (project "Espresso SDK", build "Smoke test")

## Deployment Notes

- No new secrets or infra changes
- Next release publishes an AAR without RxJava3 and with Apollo 5.0.1; consumers resolve kotlin-stdlib ≥ 2.1.0 naturally